### PR TITLE
[ENG-1114] Add preserveDataOnHide flag

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -96,6 +96,10 @@ export interface Rule {
      * The value to use for FILL_VALUE effect
      */
     value?: any;
+    /**
+     * Whether to preserve the field's value when it becomes hidden
+     */
+    preserveValueOnHide?: boolean;
   };
 }
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -204,8 +204,12 @@ const createDynamicSchema = (
         // Check if the field is hidden
         const isFieldVisible = isVisible(control, data, path, ajv);
 
-        // If field is hidden and has a value, clear it
-        if (!isFieldVisible && data[key] !== undefined) {
+        // If field is hidden and has a value, and preserveValueOnHide is not true, clear it
+        if (
+          !isFieldVisible &&
+          data[key] !== undefined &&
+          !control.rule?.options?.preserveValueOnHide
+        ) {
           // Only create a copy if we haven't already
           if (!dataChanged) {
             updatedData = { ...data };

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -2167,7 +2167,7 @@ test('core reducer - REQUIRED rule updates schema required fields when the condi
   );
 });
 
-test('core reducer - SHOW rule with preserveValueOnHide preserves field values when hidden', (t) => {
+test('SHOW rule with preserveValueOnHide should preserve field values when hidden', (t) => {
   // Create a schema with minimal fields to test functionality
   const schema = {
     type: 'object',
@@ -2178,7 +2178,7 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     },
   };
 
-  // Create a UI schema with SHOW rules and different preserveValueOnHide settings
+  // Create a UI schema with SHOW rules and preserveValueOnHide setting
   const uischema = {
     type: 'VerticalLayout',
     elements: [
@@ -2211,6 +2211,69 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
       {
         type: 'Control',
         scope: '#/properties/companyName',
+      },
+    ],
+  };
+
+  // Initial data with type 'person' and firstName filled out
+  const initialData = {
+    type: 'person',
+    firstName: 'John',
+  };
+
+  // Create initial state
+  const initialState = coreReducer(
+    undefined,
+    init(initialData, schema, uischema)
+  );
+
+  // Switch type to 'organization' which should hide firstName but preserve its value
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialData,
+        type: 'organization',
+      },
+      initialState.schema,
+      initialState.uischema
+    )
+  );
+
+  // Verify firstName is preserved even when hidden
+  t.is(
+    updatedState.data.firstName,
+    initialData.firstName,
+    'firstName should be preserved when hidden'
+  );
+});
+
+test('SHOW rule without preserveValueOnHide should clear field values when hidden', (t) => {
+  // Create a schema with minimal fields to test functionality
+  const schema = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', enum: ['person', 'organization'] },
+      firstName: { type: 'string' },
+      companyName: { type: 'string' },
+    },
+  };
+
+  // Create a UI schema with SHOW rules without preserveValueOnHide
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/type',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/firstName',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/companyName',
         rule: {
           effect: 'SHOW',
           condition: {
@@ -2231,10 +2294,9 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     ],
   };
 
-  // Initial data with type 'person' and all fields filled out
+  // Initial data with type 'organization' and companyName filled out
   const initialData = {
-    type: 'person',
-    firstName: 'John',
+    type: 'organization',
     companyName: 'Acme Corp',
   };
 
@@ -2244,59 +2306,28 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     init(initialData, schema, uischema)
   );
 
-  // Switch type to 'organization' which should:
-  // 1. Hide firstName but preserve its value (preserveValueOnHide: true)
-  // 2. Show companyName
+  // Switch type to 'person' which should hide companyName and clear its value
   const updatedState = coreReducer(
     initialState,
     updateCore(
       {
         ...initialData,
-        type: 'organization',
+        type: 'person',
       },
       initialState.schema,
       initialState.uischema
     )
   );
 
-  // Verify firstName is preserved even when hidden
-  t.is(
-    updatedState.data.firstName,
-    initialData.firstName,
-    'firstName should be preserved when hidden'
-  );
-
-  // Switch back to 'person' which should:
-  // 1. Show firstName (with preserved value)
-  // 2. Hide companyName and clear its value (no preserveValueOnHide)
-  const revertedState = coreReducer(
-    updatedState,
-    updateCore(
-      {
-        ...updatedState.data,
-        type: 'person',
-      },
-      updatedState.schema,
-      updatedState.uischema
-    )
-  );
-
-  // Verify firstName is still preserved
-  t.is(
-    revertedState.data.firstName,
-    initialData.firstName,
-    'firstName should still have its original value'
-  );
-
   // Verify companyName was cleared when hidden
   t.is(
-    revertedState.data.companyName,
+    updatedState.data.companyName,
     undefined,
     'companyName should be cleared when hidden'
   );
 });
 
-test('core reducer - HIDE rule with preserveValueOnHide preserves field values when hidden', (t) => {
+test('HIDE rule with preserveValueOnHide should preserve field values when hidden', (t) => {
   // Create a schema with minimal fields to test functionality
   const schema = {
     type: 'object',
@@ -2307,7 +2338,7 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     },
   };
 
-  // Create a UI schema with HIDE rules and different preserveValueOnHide settings
+  // Create a UI schema with HIDE rules and preserveValueOnHide setting
   const uischema = {
     type: 'VerticalLayout',
     elements: [
@@ -2340,6 +2371,69 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
       {
         type: 'Control',
         scope: '#/properties/address',
+      },
+    ],
+  };
+
+  // Initial data with type 'simple' and name filled out
+  const initialData = {
+    type: 'simple',
+    name: 'John Smith',
+  };
+
+  // Create initial state
+  const initialState = coreReducer(
+    undefined,
+    init(initialData, schema, uischema)
+  );
+
+  // Switch type to 'detailed' which should hide name but preserve its value
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialData,
+        type: 'detailed',
+      },
+      initialState.schema,
+      initialState.uischema
+    )
+  );
+
+  // Verify name is preserved even when hidden
+  t.is(
+    updatedState.data.name,
+    initialData.name,
+    'name should be preserved when hidden by HIDE rule'
+  );
+});
+
+test('HIDE rule without preserveValueOnHide should clear field values when hidden', (t) => {
+  // Create a schema with minimal fields to test functionality
+  const schema = {
+    type: 'object',
+    properties: {
+      type: { type: 'string', enum: ['simple', 'detailed'] },
+      name: { type: 'string' },
+      address: { type: 'string' },
+    },
+  };
+
+  // Create a UI schema with HIDE rules without preserveValueOnHide
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/type',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/name',
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/address',
         rule: {
           effect: 'HIDE',
           condition: {
@@ -2360,10 +2454,9 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     ],
   };
 
-  // Initial data with type 'simple' and all fields filled out
+  // Initial data with type 'detailed' and address filled out
   const initialData = {
-    type: 'simple',
-    name: 'John Smith',
+    type: 'detailed',
     address: '123 Main St',
   };
 
@@ -2373,53 +2466,22 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     init(initialData, schema, uischema)
   );
 
-  // Switch type to 'detailed' which should:
-  // 1. Hide name but preserve its value (preserveValueOnHide: true)
-  // 2. Show address
+  // Switch type to 'simple' which should hide address and clear its value
   const updatedState = coreReducer(
     initialState,
     updateCore(
       {
         ...initialData,
-        type: 'detailed',
+        type: 'simple',
       },
       initialState.schema,
       initialState.uischema
     )
   );
 
-  // Verify name is preserved even when hidden
-  t.is(
-    updatedState.data.name,
-    initialData.name,
-    'name should be preserved when hidden by HIDE rule'
-  );
-
-  // Switch back to 'simple' which should:
-  // 1. Show name (with preserved value)
-  // 2. Hide address and clear its value (no preserveValueOnHide)
-  const revertedState = coreReducer(
-    updatedState,
-    updateCore(
-      {
-        ...updatedState.data,
-        type: 'simple',
-      },
-      updatedState.schema,
-      updatedState.uischema
-    )
-  );
-
-  // Verify name is still preserved
-  t.is(
-    revertedState.data.name,
-    initialData.name,
-    'name should still have its original value after being shown again'
-  );
-
   // Verify address was cleared when hidden
   t.is(
-    revertedState.data.address,
+    updatedState.data.address,
     undefined,
     'address should be cleared when hidden by HIDE rule'
   );

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -2168,25 +2168,13 @@ test('core reducer - REQUIRED rule updates schema required fields when the condi
 });
 
 test('core reducer - SHOW rule with preserveValueOnHide preserves field values when hidden', (t) => {
-  // Create a schema with fields that will be conditionally shown/hidden
+  // Create a schema with minimal fields to test functionality
   const schema = {
     type: 'object',
     properties: {
       type: { type: 'string', enum: ['person', 'organization'] },
-      personalInfo: {
-        type: 'object',
-        properties: {
-          firstName: { type: 'string' },
-          lastName: { type: 'string' },
-        },
-      },
-      organizationInfo: {
-        type: 'object',
-        properties: {
-          companyName: { type: 'string' },
-          registrationNumber: { type: 'string' },
-        },
-      },
+      firstName: { type: 'string' },
+      companyName: { type: 'string' },
     },
   };
 
@@ -2196,11 +2184,11 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     elements: [
       {
         type: 'Control',
-        scope: 'type',
+        scope: '#/properties/type',
       },
       {
         type: 'Control',
-        scope: 'personalInfo',
+        scope: '#/properties/firstName',
         rule: {
           effect: 'SHOW',
           condition: {
@@ -2222,7 +2210,7 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
       },
       {
         type: 'Control',
-        scope: 'organizationInfo',
+        scope: '#/properties/companyName',
         rule: {
           effect: 'SHOW',
           condition: {
@@ -2243,17 +2231,11 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     ],
   };
 
-  // Initial data with type 'person' and both sets of info filled out
+  // Initial data with type 'person' and all fields filled out
   const initialData = {
     type: 'person',
-    personalInfo: {
-      firstName: 'John',
-      lastName: 'Doe',
-    },
-    organizationInfo: {
-      companyName: 'Acme Corp',
-      registrationNumber: '12345',
-    },
+    firstName: 'John',
+    companyName: 'Acme Corp',
   };
 
   // Create initial state
@@ -2263,8 +2245,8 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
   );
 
   // Switch type to 'organization' which should:
-  // 1. Hide personalInfo but preserve its value (preserveValueOnHide: true)
-  // 2. Show organizationInfo
+  // 1. Hide firstName but preserve its value (preserveValueOnHide: true)
+  // 2. Show companyName
   const updatedState = coreReducer(
     initialState,
     updateCore(
@@ -2277,16 +2259,16 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     )
   );
 
-  // Verify personalInfo is preserved even when hidden
-  t.deepEqual(
-    updatedState.data.personalInfo,
-    initialData.personalInfo,
-    'personalInfo should be preserved when hidden'
+  // Verify firstName is preserved even when hidden
+  t.is(
+    updatedState.data.firstName,
+    initialData.firstName,
+    'firstName should be preserved when hidden'
   );
 
   // Switch back to 'person' which should:
-  // 1. Show personalInfo (with preserved values)
-  // 2. Hide organizationInfo and clear its value (no preserveValueOnHide)
+  // 1. Show firstName (with preserved value)
+  // 2. Hide companyName and clear its value (no preserveValueOnHide)
   const revertedState = coreReducer(
     updatedState,
     updateCore(
@@ -2299,41 +2281,29 @@ test('core reducer - SHOW rule with preserveValueOnHide preserves field values w
     )
   );
 
-  // Verify personalInfo is still preserved
-  t.deepEqual(
-    revertedState.data.personalInfo,
-    initialData.personalInfo,
-    'personalInfo should still have its original values'
+  // Verify firstName is still preserved
+  t.is(
+    revertedState.data.firstName,
+    initialData.firstName,
+    'firstName should still have its original value'
   );
 
-  // Verify organizationInfo was cleared when hidden
+  // Verify companyName was cleared when hidden
   t.is(
-    revertedState.data.organizationInfo,
+    revertedState.data.companyName,
     undefined,
-    'organizationInfo should be cleared when hidden'
+    'companyName should be cleared when hidden'
   );
 });
 
 test('core reducer - HIDE rule with preserveValueOnHide preserves field values when hidden', (t) => {
-  // Create a schema with fields that will be conditionally hidden
+  // Create a schema with minimal fields to test functionality
   const schema = {
     type: 'object',
     properties: {
       type: { type: 'string', enum: ['simple', 'detailed'] },
-      basicInfo: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          email: { type: 'string' },
-        },
-      },
-      detailedInfo: {
-        type: 'object',
-        properties: {
-          address: { type: 'string' },
-          phone: { type: 'string' },
-        },
-      },
+      name: { type: 'string' },
+      address: { type: 'string' },
     },
   };
 
@@ -2343,11 +2313,11 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     elements: [
       {
         type: 'Control',
-        scope: 'type',
+        scope: '#/properties/type',
       },
       {
         type: 'Control',
-        scope: 'basicInfo',
+        scope: '#/properties/name',
         rule: {
           effect: 'HIDE',
           condition: {
@@ -2369,7 +2339,7 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
       },
       {
         type: 'Control',
-        scope: 'detailedInfo',
+        scope: '#/properties/address',
         rule: {
           effect: 'HIDE',
           condition: {
@@ -2390,17 +2360,11 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     ],
   };
 
-  // Initial data with type 'simple' and both sets of info filled out
+  // Initial data with type 'simple' and all fields filled out
   const initialData = {
     type: 'simple',
-    basicInfo: {
-      name: 'John Smith',
-      email: 'john@example.com',
-    },
-    detailedInfo: {
-      address: '123 Main St',
-      phone: '555-0123',
-    },
+    name: 'John Smith',
+    address: '123 Main St',
   };
 
   // Create initial state
@@ -2410,8 +2374,8 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
   );
 
   // Switch type to 'detailed' which should:
-  // 1. Hide basicInfo but preserve its value (preserveValueOnHide: true)
-  // 2. Show detailedInfo
+  // 1. Hide name but preserve its value (preserveValueOnHide: true)
+  // 2. Show address
   const updatedState = coreReducer(
     initialState,
     updateCore(
@@ -2424,16 +2388,16 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     )
   );
 
-  // Verify basicInfo is preserved even when hidden
-  t.deepEqual(
-    updatedState.data.basicInfo,
-    initialData.basicInfo,
-    'basicInfo should be preserved when hidden by HIDE rule'
+  // Verify name is preserved even when hidden
+  t.is(
+    updatedState.data.name,
+    initialData.name,
+    'name should be preserved when hidden by HIDE rule'
   );
 
   // Switch back to 'simple' which should:
-  // 1. Show basicInfo (with preserved values)
-  // 2. Hide detailedInfo and clear its value (no preserveValueOnHide)
+  // 1. Show name (with preserved value)
+  // 2. Hide address and clear its value (no preserveValueOnHide)
   const revertedState = coreReducer(
     updatedState,
     updateCore(
@@ -2446,17 +2410,17 @@ test('core reducer - HIDE rule with preserveValueOnHide preserves field values w
     )
   );
 
-  // Verify basicInfo is still preserved
-  t.deepEqual(
-    revertedState.data.basicInfo,
-    initialData.basicInfo,
-    'basicInfo should still have its original values after being shown again'
+  // Verify name is still preserved
+  t.is(
+    revertedState.data.name,
+    initialData.name,
+    'name should still have its original value after being shown again'
   );
 
-  // Verify detailedInfo was cleared when hidden
+  // Verify address was cleared when hidden
   t.is(
-    revertedState.data.detailedInfo,
+    revertedState.data.address,
     undefined,
-    'detailedInfo should be cleared when hidden by HIDE rule'
+    'address should be cleared when hidden by HIDE rule'
   );
 });


### PR DESCRIPTION
This adds a flag to rules to preserve the data on HIDE. This will be necessary when we want to simply store data in hidden fields to drive logic. The base behavior of clearing fields will remain, but when this flag is set to true we will preserve data on hidden fields. There will be a follow up to create a toggle in the form builder to trigger this flag.