### PR TITLE
ENG-390: Support min and max value for date-time material-renderer components.

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -668,7 +668,7 @@ export const mapDispatchToControlProps = (
   dispatch: Dispatch<AnyAction>
 ): DispatchPropsOfControl => ({
   handleChange(path, value) {
-    dispatch(update(path, () => value));
+    dispatch && dispatch(update(path, () => value));
   },
 });
 

--- a/packages/examples/src/examples/dates.ts
+++ b/packages/examples/src/examples/dates.ts
@@ -75,14 +75,26 @@ export const uischema = {
         {
           type: 'Control',
           scope: '#/properties/schemaBased/properties/date',
+          options: {
+            maxValue: '2025-03-26',
+            minValue: '2025-03-19',
+          },
         },
         {
           type: 'Control',
           scope: '#/properties/schemaBased/properties/time',
+          options: {
+            maxValue: '18:50',
+            minValue: '10:10',
+          },
         },
         {
           type: 'Control',
           scope: '#/properties/schemaBased/properties/datetime',
+          options: {
+            maxValue: '2025-03-26 10:30',
+            minValue: '2025-03-19 18:30',
+          },
         },
       ],
     },
@@ -101,6 +113,8 @@ export const uischema = {
             views: ['year', 'month'],
             dateFormat: 'YYYY.MM',
             dateSaveFormat: 'YYYY-MM',
+            maxValue: '2025-03-31',
+            minValue: '2025-03-19',
           },
         },
         {
@@ -109,6 +123,10 @@ export const uischema = {
           options: {
             format: 'time',
             ampm: true,
+            options: {
+              maxValue: '18:50',
+              minValue: '10:10',
+            },
           },
         },
         {
@@ -119,6 +137,10 @@ export const uischema = {
             dateTimeFormat: 'DD-MM-YY hh:mm:a',
             dateTimeSaveFormat: 'YYYY/MM/DD h:mm a',
             ampm: true,
+            options: {
+              maxValue: '2025-03-26 22:15',
+              minValue: '2025-03-19 10:10',
+            },
           },
         },
       ],

--- a/packages/material-renderers/src/controls/MaterialDateControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateControl.tsx
@@ -42,6 +42,7 @@ import {
   getData,
   useFocus,
 } from '../util';
+import dayjs from 'dayjs';
 
 export const MaterialDateControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
@@ -108,6 +109,10 @@ export const MaterialDateControl = (props: ControlProps) => {
     return null;
   }
 
+  const maxDate = dayjs(appliedUiSchemaOptions?.maxValue, 'YYYY-MM-DD');
+
+  const minDate = dayjs(appliedUiSchemaOptions?.minValue, 'YYYY-MM-DD');
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DatePicker
@@ -118,6 +123,8 @@ export const MaterialDateControl = (props: ControlProps) => {
         label={label}
         value={value}
         onAccept={onChange}
+        maxDate={maxDate}
+        minDate={minDate}
         format={format}
         views={views}
         disabled={!enabled}
@@ -135,6 +142,7 @@ export const MaterialDateControl = (props: ControlProps) => {
             fullWidth: !appliedUiSchemaOptions.trim,
             inputProps: {
               type: 'text',
+              readonly: true,
             },
             InputLabelProps: data ? { shrink: true } : undefined,
             onFocus: onFocus,

--- a/packages/material-renderers/src/controls/MaterialDateControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateControl.tsx
@@ -44,6 +44,8 @@ import {
 } from '../util';
 import dayjs from 'dayjs';
 
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+
 export const MaterialDateControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
   const {
@@ -72,7 +74,7 @@ export const MaterialDateControl = (props: ControlProps) => {
   const [key, setKey] = useState<number>(0);
   const [open, setOpen] = useState<boolean>(false);
 
-  const format = appliedUiSchemaOptions.dateFormat ?? 'YYYY-MM-DD';
+  const format = appliedUiSchemaOptions.dateFormat ?? DEFAULT_DATE_FORMAT;
   const saveFormat = appliedUiSchemaOptions.dateSaveFormat ?? defaultDateFormat;
 
   const views = appliedUiSchemaOptions.views ?? ['year', 'day'];
@@ -109,9 +111,9 @@ export const MaterialDateControl = (props: ControlProps) => {
     return null;
   }
 
-  const maxDate = dayjs(appliedUiSchemaOptions?.maxValue, 'YYYY-MM-DD');
+  const maxDate = dayjs(appliedUiSchemaOptions?.maxValue, DEFAULT_DATE_FORMAT);
 
-  const minDate = dayjs(appliedUiSchemaOptions?.minValue, 'YYYY-MM-DD');
+  const minDate = dayjs(appliedUiSchemaOptions?.minValue, DEFAULT_DATE_FORMAT);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>

--- a/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
@@ -44,6 +44,8 @@ import {
   useFocus,
 } from '../util';
 
+const DEFAULT_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm';
+
 export const MaterialDateTimeControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
   const {
@@ -70,7 +72,8 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
     appliedUiSchemaOptions.showUnfocusedDescription
   );
 
-  const format = appliedUiSchemaOptions.dateTimeFormat ?? 'YYYY-MM-DD HH:mm';
+  const format =
+    appliedUiSchemaOptions.dateTimeFormat ?? DEFAULT_DATE_TIME_FORMAT;
   const saveFormat =
     appliedUiSchemaOptions.dateTimeSaveFormat ?? defaultDateTimeFormat;
 
@@ -118,12 +121,12 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
 
   const maxDateTime = dayjs(
     appliedUiSchemaOptions?.maxValue,
-    'YYYY-MM-DD HH:mm'
+    DEFAULT_DATE_TIME_FORMAT
   );
 
   const minDateTime = dayjs(
     appliedUiSchemaOptions?.minValue,
-    'YYYY-MM-DD HH:mm'
+    DEFAULT_DATE_TIME_FORMAT
   );
 
   return (

--- a/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
@@ -23,6 +23,7 @@
   THE SOFTWARE.
 */
 import React, { useCallback, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 import merge from 'lodash/merge';
 import {
   ControlProps,
@@ -114,6 +115,17 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
   if (!visible) {
     return null;
   }
+
+  const maxDateTime = dayjs(
+    appliedUiSchemaOptions?.maxValue,
+    'YYYY-MM-DD HH:mm'
+  );
+
+  const minDateTime = dayjs(
+    appliedUiSchemaOptions?.minValue,
+    'YYYY-MM-DD HH:mm'
+  );
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DateTimePicker
@@ -123,6 +135,8 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
         key={key}
         label={label}
         value={value}
+        maxDateTime={maxDateTime}
+        minDateTime={minDateTime}
         onAccept={onChange}
         format={format}
         ampm={!!appliedUiSchemaOptions.ampm}

--- a/packages/material-renderers/src/controls/MaterialTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialTimeControl.tsx
@@ -44,6 +44,8 @@ import {
   useFocus,
 } from '../util';
 
+const DEFAULT_TIME_FORMAT = 'HH:mm';
+
 export const MaterialTimeControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
   const {
@@ -73,7 +75,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
     appliedUiSchemaOptions.showUnfocusedDescription
   );
 
-  const format = appliedUiSchemaOptions.timeFormat ?? 'HH:mm';
+  const format = appliedUiSchemaOptions.timeFormat ?? DEFAULT_TIME_FORMAT;
   const saveFormat = appliedUiSchemaOptions.timeSaveFormat ?? defaultTimeFormat;
 
   const views = appliedUiSchemaOptions.views ?? ['hours', 'minutes'];
@@ -106,8 +108,8 @@ export const MaterialTimeControl = (props: ControlProps) => {
   );
   const value = getData(data, saveFormat);
 
-  const minTime = dayjs(appliedUiSchemaOptions?.minValue, 'HH:mm');
-  const maxTime = dayjs(appliedUiSchemaOptions?.maxValue, 'HH:mm');
+  const minTime = dayjs(appliedUiSchemaOptions?.minValue, DEFAULT_TIME_FORMAT);
+  const maxTime = dayjs(appliedUiSchemaOptions?.maxValue, DEFAULT_TIME_FORMAT);
 
   if (!visible) {
     return null;

--- a/packages/material-renderers/src/controls/MaterialTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialTimeControl.tsx
@@ -22,6 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+import dayjs from 'dayjs';
 import React, { useCallback, useMemo, useState } from 'react';
 import merge from 'lodash/merge';
 import {
@@ -105,6 +106,9 @@ export const MaterialTimeControl = (props: ControlProps) => {
   );
   const value = getData(data, saveFormat);
 
+  const minTime = dayjs(appliedUiSchemaOptions?.minValue, 'HH:mm');
+  const maxTime = dayjs(appliedUiSchemaOptions?.maxValue, 'HH:mm');
+
   if (!visible) {
     return null;
   }
@@ -117,6 +121,8 @@ export const MaterialTimeControl = (props: ControlProps) => {
         key={key}
         label={label}
         value={value}
+        maxTime={maxTime}
+        minTime={minTime}
         onAccept={onChange}
         format={format}
         ampm={!!appliedUiSchemaOptions.ampm}

--- a/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
@@ -423,29 +423,28 @@ describe('Material date control', () => {
     input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('04---1961');
   });
-});
 
-it('should render with a placeholder', () => {
-  const control: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      placeholder: 'Select a date',
-    },
-  };
-  const core = initCore(schema, control, data);
-  const wrapper = mount(
-    <JsonFormsStateProvider initState={{ renderers: materialRenderers, core }}>
-      <MaterialDateControl schema={schema} uischema={control} />
-    </JsonFormsStateProvider>
-  );
+  it('should render with a placeholder', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        placeholder: 'Select a date',
+      },
+    };
+    const core = initCore(schema, control, data);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={control} />
+      </JsonFormsStateProvider>
+    );
 
-  // Log the rendered component tree for debugging
-  console.log(wrapper.debug());
+    // Find the input element
+    const inputElement = wrapper.find('input').first();
 
-  // Find the input element
-  const inputElement = wrapper.find('input').first();
-
-  // Check the placeholder attribute
-  expect(inputElement.props().placeholder).toBe('Select a date');
+    // Check the placeholder attribute
+    expect(inputElement.props().placeholder).toBe('Select a date');
+  });
 });


### PR DESCRIPTION
https://linear.app/avantos/issue/ENG-390/implement-date-restrictions

- Add minValue and maxValue to the uiSchema.
- Use dayjs to format schema received date property.
- Add max and min values to the Time, Date, and DateTime components. 