### PR TITLE
ENG-1178: Filter elements by visibility before rendering them in layout.

### DIFF
--- a/packages/material-renderers/src/layouts/MaterialGroupLayout.tsx
+++ b/packages/material-renderers/src/layouts/MaterialGroupLayout.tsx
@@ -27,6 +27,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader } from '@mui/material';
 import {
   GroupLayout,
+  isVisible,
   LayoutProps,
   RankedTester,
   rankWith,
@@ -34,13 +35,21 @@ import {
   withIncreasedRank,
 } from '@mosaic-avantos/jsonforms-core';
 import {
+  AjvProps,
   MaterialLabelableLayoutRendererProps,
   MaterialLayoutRenderer,
+  withAjvProps,
 } from '../util/layout';
 import { withJsonFormsLayoutProps } from '@mosaic-avantos/jsonforms-react';
 
 export const groupTester: RankedTester = rankWith(1, uiTypeIs('Group'));
 const style: { [x: string]: any } = { marginBottom: '10px' };
+
+export interface MaterializedGroupLayoutRendererProps
+  extends LayoutProps,
+    AjvProps {
+  data?: any;
+}
 
 const GroupComponent = React.memo(function GroupComponent({
   visible,
@@ -80,12 +89,18 @@ export const MaterializedGroupLayoutRenderer = ({
   cells,
   direction,
   label,
-}: LayoutProps) => {
+  ajv,
+  data,
+}: MaterializedGroupLayoutRendererProps) => {
   const groupLayout = uischema as GroupLayout;
+
+  const visibleElements = groupLayout.elements?.filter((element) =>
+    isVisible(element, data, path, ajv)
+  );
 
   return (
     <GroupComponent
-      elements={groupLayout.elements}
+      elements={visibleElements}
       schema={schema}
       path={path}
       direction={direction}
@@ -99,7 +114,9 @@ export const MaterializedGroupLayoutRenderer = ({
   );
 };
 
-export default withJsonFormsLayoutProps(MaterializedGroupLayoutRenderer);
+export default withAjvProps(
+  withJsonFormsLayoutProps(MaterializedGroupLayoutRenderer)
+);
 
 export const materialGroupTester: RankedTester = withIncreasedRank(
   1,

--- a/packages/material-renderers/src/layouts/MaterialHorizontalLayout.tsx
+++ b/packages/material-renderers/src/layouts/MaterialHorizontalLayout.tsx
@@ -25,6 +25,7 @@
 import React from 'react';
 import {
   HorizontalLayout,
+  isVisible,
   LayoutProps,
   RankedTester,
   rankWith,
@@ -32,8 +33,10 @@ import {
 } from '@mosaic-avantos/jsonforms-core';
 import { withJsonFormsLayoutProps } from '@mosaic-avantos/jsonforms-react';
 import {
+  AjvProps,
   MaterialLayoutRenderer,
   MaterialLayoutRendererProps,
+  withAjvProps,
 } from '../util/layout';
 
 /**
@@ -45,6 +48,12 @@ export const materialHorizontalLayoutTester: RankedTester = rankWith(
   uiTypeIs('HorizontalLayout')
 );
 
+export interface MaterialHorizontalLayoutRendererProps
+  extends LayoutProps,
+    AjvProps {
+  data?: any;
+}
+
 export const MaterialHorizontalLayoutRenderer = ({
   uischema,
   renderers,
@@ -53,10 +62,17 @@ export const MaterialHorizontalLayoutRenderer = ({
   path,
   enabled,
   visible,
-}: LayoutProps) => {
+  ajv,
+  data,
+}: MaterialHorizontalLayoutRendererProps) => {
   const layout = uischema as HorizontalLayout;
+
+  const visibleElements = layout.elements?.filter((element) =>
+    isVisible(element, data, path, ajv)
+  );
+
   const childProps: MaterialLayoutRendererProps = {
-    elements: layout.elements,
+    elements: visibleElements,
     schema,
     path,
     enabled,
@@ -73,4 +89,6 @@ export const MaterialHorizontalLayoutRenderer = ({
   );
 };
 
-export default withJsonFormsLayoutProps(MaterialHorizontalLayoutRenderer);
+export default withAjvProps(
+  withJsonFormsLayoutProps(MaterialHorizontalLayoutRenderer)
+);

--- a/packages/material-renderers/src/layouts/MaterialVerticalLayout.tsx
+++ b/packages/material-renderers/src/layouts/MaterialVerticalLayout.tsx
@@ -24,15 +24,19 @@
 */
 import React from 'react';
 import {
+  isVisible,
   LayoutProps,
   RankedTester,
   rankWith,
   uiTypeIs,
   VerticalLayout,
 } from '@mosaic-avantos/jsonforms-core';
+
 import {
+  AjvProps,
   MaterialLayoutRenderer,
   MaterialLayoutRendererProps,
+  withAjvProps,
 } from '../util/layout';
 import { withJsonFormsLayoutProps } from '@mosaic-avantos/jsonforms-react';
 
@@ -45,6 +49,12 @@ export const materialVerticalLayoutTester: RankedTester = rankWith(
   uiTypeIs('VerticalLayout')
 );
 
+export interface MaterialVerticalLayoutRendererProps
+  extends LayoutProps,
+    AjvProps {
+  data?: any;
+}
+
 export const MaterialVerticalLayoutRenderer = ({
   uischema,
   schema,
@@ -53,10 +63,16 @@ export const MaterialVerticalLayoutRenderer = ({
   visible,
   renderers,
   cells,
-}: LayoutProps) => {
+  ajv,
+  data,
+}: MaterialVerticalLayoutRendererProps) => {
   const verticalLayout = uischema as VerticalLayout;
+
+  const visibleElements = verticalLayout.elements?.filter((element) =>
+    isVisible(element, data, path, ajv)
+  );
   const childProps: MaterialLayoutRendererProps = {
-    elements: verticalLayout.elements,
+    elements: visibleElements,
     schema,
     path,
     enabled,
@@ -73,4 +89,6 @@ export const MaterialVerticalLayoutRenderer = ({
   );
 };
 
-export default withJsonFormsLayoutProps(MaterialVerticalLayoutRenderer);
+export default withAjvProps(
+  withJsonFormsLayoutProps(MaterialVerticalLayoutRenderer)
+);

--- a/packages/material-renderers/test/renderers/MaterialGroupLayout.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialGroupLayout.test.tsx
@@ -27,8 +27,11 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MaterialGroupLayout from '../../src/layouts/MaterialGroupLayout';
 import { MaterialLayoutRenderer } from '../../src/util/layout';
+import { createAjv } from '@mosaic-avantos/jsonforms-core/src/util';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+const ajv = createAjv();
 
 const schema = {
   type: 'object',
@@ -73,6 +76,7 @@ describe('Material group layout', () => {
         enabled
         visible
         path=''
+        ajv={ajv}
       />
     );
     expect(wrapper.find(MaterialLayoutRenderer).props().direction).toBe(
@@ -89,6 +93,7 @@ describe('Material group layout', () => {
         enabled
         visible
         path=''
+        ajv={ajv}
       />
     );
     expect(wrapper.find(MaterialLayoutRenderer).props().direction).toBe('row');

--- a/packages/material-renderers/test/renderers/MaterialInputControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialInputControl.test.tsx
@@ -45,6 +45,9 @@ import { MaterialInputControl } from '../../src/controls/MaterialInputControl';
 import MaterialHorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
 import { MuiInputText } from '../../src/mui-controls';
 import { initCore } from './util';
+import { createAjv } from '@mosaic-avantos/jsonforms-core/src/util';
+
+const ajv = createAjv();
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -276,6 +279,7 @@ describe('Material input control', () => {
           enabled
           visible
           path=''
+          ajv={ajv}
         />
       </JsonFormsStateProvider>
     );


### PR DESCRIPTION
- Remove empty space created from hidden fields by filtering the hidden elements before passing them to the layout.
- Use the Avj wrapper and pass data to horizontal, group, and vertical layouts.
- Update existing tests.

Form:
<img width="743" alt="Screenshot 2025-04-03 at 22 31 29" src="https://github.com/user-attachments/assets/903b79f8-f01b-458c-ad28-ce523675d203" />

Preview:
<img width="836" alt="Screenshot 2025-04-03 at 22 31 50" src="https://github.com/user-attachments/assets/e559de0b-4476-46fc-84b8-3d905e0ec292" />



