### PR TITLE
ENG-1169: Add dynamic date restrictions.

### DIFF
--- a/packages/examples/src/examples/dates.ts
+++ b/packages/examples/src/examples/dates.ts
@@ -103,6 +103,33 @@ export const uischema = {
       elements: [
         {
           type: 'Control',
+          scope: '#/properties/schemaBased/properties/date',
+          options: {
+            maxValue: 'Today',
+          },
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/schemaBased/properties/time',
+          options: {
+            maxValue: '18:50',
+            minValue: '10:10',
+          },
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/schemaBased/properties/datetime',
+          options: {
+            minValue: 'Today',
+          },
+        },
+      ],
+    },
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'Control',
           scope: '#/properties/uiSchemaBased/properties/date',
           label: 'Year Month Picker',
           options: {

--- a/packages/material-renderers/src/controls/MaterialDateControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateControl.tsx
@@ -45,6 +45,7 @@ import {
 import dayjs from 'dayjs';
 
 const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
+export const RELATIVE_DATE_TODAY = 'Today';
 
 export const MaterialDateControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
@@ -111,9 +112,25 @@ export const MaterialDateControl = (props: ControlProps) => {
     return null;
   }
 
-  const maxDate = dayjs(appliedUiSchemaOptions?.maxValue, DEFAULT_DATE_FORMAT);
+  const today = dayjs().startOf('day');
 
-  const minDate = dayjs(appliedUiSchemaOptions?.minValue, DEFAULT_DATE_FORMAT);
+  const parseDateBound = (
+    value: string | undefined
+  ): dayjs.Dayjs | undefined => {
+    if (!value) return undefined;
+    if (value === RELATIVE_DATE_TODAY) return today;
+    return dayjs(value, DEFAULT_DATE_FORMAT);
+  };
+
+  const maxDate = useMemo(
+    () => parseDateBound(appliedUiSchemaOptions?.maxValue),
+    [appliedUiSchemaOptions?.maxValue]
+  );
+
+  const minDate = useMemo(
+    () => parseDateBound(appliedUiSchemaOptions?.minValue),
+    [appliedUiSchemaOptions?.minValue]
+  );
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>

--- a/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
@@ -45,6 +45,7 @@ import {
 } from '../util';
 
 const DEFAULT_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm';
+const RELATIVE_DATE_TODAY = 'Today';
 
 export const MaterialDateTimeControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
@@ -119,16 +120,25 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
     return null;
   }
 
-  const maxDateTime = dayjs(
-    appliedUiSchemaOptions?.maxValue,
-    DEFAULT_DATE_TIME_FORMAT
+  const now = dayjs();
+
+  const parseDateTimeBound = (
+    value: string | undefined
+  ): dayjs.Dayjs | undefined => {
+    if (!value) return undefined;
+    if (value === RELATIVE_DATE_TODAY) return now;
+    return dayjs(value, DEFAULT_DATE_TIME_FORMAT);
+  };
+
+  const maxDateTime = useMemo(
+    () => parseDateTimeBound(appliedUiSchemaOptions?.maxValue),
+    [appliedUiSchemaOptions?.maxValue]
   );
 
-  const minDateTime = dayjs(
-    appliedUiSchemaOptions?.minValue,
-    DEFAULT_DATE_TIME_FORMAT
+  const minDateTime = useMemo(
+    () => parseDateTimeBound(appliedUiSchemaOptions?.minValue),
+    [appliedUiSchemaOptions?.minValue]
   );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DateTimePicker


### PR DESCRIPTION
- Utilize already existing minValue and maxValue to enable dynamic date restriction. 
- If the user should only be able to select future dates, the "Today" value will be added to maxValue.
- If the user should only be able to select past dates, the "Today" value will be added to maxValue.