### PR TITLE
Eng-1753: Make the URL clickable in the text field.

### DIFF
--- a/packages/material-renderers/src/controls/MaterialInputControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialInputControl.tsx
@@ -104,6 +104,7 @@ export const MaterialInputControl = (props: ControlProps & WithInput) => {
         id={id + '-input'}
         isValid={isValid}
         visible={visible}
+        focused={focused}
       />
       <FormHelperText error={!isValid && !showDescription}>
         {firstFormHelperText}

--- a/packages/material-renderers/src/mui-controls/MuiInputText.tsx
+++ b/packages/material-renderers/src/mui-controls/MuiInputText.tsx
@@ -40,6 +40,8 @@ import {
   useInputComponent,
 } from '../util';
 
+import LaunchIcon from '@mui/icons-material/Launch';
+
 interface MuiTextInputProps {
   muiInputProps?: InputProps['inputProps'];
   inputComponent?: InputProps['inputComponent'];
@@ -85,6 +87,9 @@ export const MuiInputText = React.memo(function MuiInputText(
     inputProps.size = maxLength;
   }
 
+  const isUrl = (text: string | undefined) =>
+    typeof text === 'string' && /^(https?:\/\/[^\s]+)$/i.test(text);
+
   const [inputText, onChange, onClear] = useDebouncedChange(
     handleChange,
     '',
@@ -97,7 +102,7 @@ export const MuiInputText = React.memo(function MuiInputText(
 
   const theme: JsonFormsTheme = useTheme();
 
-  const closeStyle = {
+  const iconStyles = {
     background:
       theme.jsonforms?.input?.delete?.background ||
       theme.palette.background.default,
@@ -133,12 +138,24 @@ export const MuiInputText = React.memo(function MuiInputText(
             right: 0,
           }}
         >
+          {isUrl(inputText) && (
+            <IconButton
+              aria-label='Open link in new tab'
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(inputText, '_blank', 'noopener,noreferrer');
+              }}
+              size='small'
+            >
+              <LaunchIcon style={iconStyles} />
+            </IconButton>
+          )}
           <IconButton
             aria-label='Clear input field'
             onClick={onClear}
-            size='large'
+            size='small'
           >
-            <Close style={closeStyle} />
+            <Close style={iconStyles} />
           </IconButton>
         </InputAdornment>
       }

--- a/packages/material-renderers/src/mui-controls/MuiInputText.tsx
+++ b/packages/material-renderers/src/mui-controls/MuiInputText.tsx
@@ -53,7 +53,10 @@ const eventToValue = (ev: any) => {
 };
 
 export const MuiInputText = React.memo(function MuiInputText(
-  props: CellProps & WithClassname & MuiTextInputProps & WithInputProps
+  props: CellProps &
+    WithClassname &
+    MuiTextInputProps &
+    WithInputProps & { focused?: boolean }
 ) {
   const [showAdornment, setShowAdornment] = useState(false);
   const {
@@ -69,6 +72,7 @@ export const MuiInputText = React.memo(function MuiInputText(
     schema,
     muiInputProps,
     label,
+    focused,
     inputComponent,
   } = props;
   const InputComponent = useInputComponent();
@@ -131,11 +135,9 @@ export const MuiInputText = React.memo(function MuiInputText(
           position='end'
           style={{
             display:
-              !showAdornment || !enabled || data === undefined
-                ? 'none'
-                : 'flex',
-            position: 'absolute',
-            right: 0,
+              (showAdornment || focused) && enabled && data !== undefined
+                ? 'flex'
+                : 'none',
           }}
         >
           {isUrl(inputText) && (


### PR DESCRIPTION
<!--- Provide a one-line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description
- We want to be able to navigate to the link(URL) when added to the text field. There are few options for that, but in this draft it is implemented with "visit" icon at the end of the input field.
<img width="823" alt="Screenshot 2025-05-21 at 17 31 18" src="https://github.com/user-attachments/assets/32f4ced6-f534-4972-ba8a-efd1e70b4a52" />
This image shows one focused field(root) and one hovered field(array)

## Motivation and Context
https://linear.app/avantos/issue/ENG-1753/when-url-is-added-to-text-field-show-it-as-hyperlink
<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self-review of my code.
- [x] I have updated the documentation / READMEs where necessary.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
