### PR TITLE
[ENG3-571] Date picker do not open the first time it is clicked

### DIFF
--- a/packages/material-renderers/src/controls/MaterialDateControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateControl.tsx
@@ -161,7 +161,7 @@ export const MaterialDateControl = (props: ControlProps) => {
             fullWidth: !appliedUiSchemaOptions.trim,
             inputProps: {
               type: 'text',
-              readonly: true,
+              readOnly: true,
             },
             InputLabelProps: data ? { shrink: true } : undefined,
             onFocus: onFocus,

--- a/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
@@ -169,7 +169,7 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
             fullWidth: !appliedUiSchemaOptions.trim,
             inputProps: {
               type: 'text',
-              readonly: true,
+              readOnly: true,
             },
             InputLabelProps: data ? { shrink: true } : undefined,
             onFocus: onFocus,

--- a/packages/material-renderers/src/controls/MaterialTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialTimeControl.tsx
@@ -143,7 +143,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
             fullWidth: !appliedUiSchemaOptions.trim,
             inputProps: {
               type: 'text',
-              readonly: true,
+              readOnly: true,
             },
             InputLabelProps: data ? { shrink: true } : undefined,
             onFocus: onFocus,

--- a/packages/material-renderers/src/util/datejs.tsx
+++ b/packages/material-renderers/src/util/datejs.tsx
@@ -31,10 +31,15 @@ export const createOnBlurHandler =
   (e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>) => {
     const date = dayjs(e.target.value, format);
     const formatedDate = formatDate(date, saveFormat);
+    // Check if the input value is a date/time format string. Initially, a date format is sent when the user clicks the empty field.
     if (
-      formatedDate.toString() === 'Invalid Date' &&
-      e.target.value !== format
+      /^((?:[DMY]{2,4}(?:[-/:\s.]+[DMY]{2,4}){0,2}|\b[DMY]+\b)\s*)?([HhmsAa]+[-/:\s.]+[HhmsAa]+[-/:\s.]*[HhmsAa]*)?$/i.test(
+        e.target.value
+      )
     ) {
+      handleChange(path, undefined);
+      // don't rerender so user can click the date picker.
+    } else if (formatedDate.toString() === 'Invalid Date') {
       handleChange(path, undefined);
       rerenderChild();
     } else {

--- a/packages/material-renderers/src/util/datejs.tsx
+++ b/packages/material-renderers/src/util/datejs.tsx
@@ -31,7 +31,10 @@ export const createOnBlurHandler =
   (e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>) => {
     const date = dayjs(e.target.value, format);
     const formatedDate = formatDate(date, saveFormat);
-    if (formatedDate.toString() === 'Invalid Date') {
+    if (
+      formatedDate.toString() === 'Invalid Date' &&
+      e.target.value !== format
+    ) {
       handleChange(path, undefined);
       rerenderChild();
     } else {


### PR DESCRIPTION
Check for initial value to prevent rerendering on blur.
## Description
Previously, clicking on the date field then clicking on the date picker button would not open the date picker. This is because the onBlurHandler was being called when the user clicked on the button while the input was focused. Since the input was empty, the onBlurHandler would detect invalid date, and cause a rerender, preventing the date picker from showing.

Fixed by adding a condition in onBlueHandler that checks if the input is the initial input, a format string. Used regex since the mui date picker will change the format sometimes, for example hh:mm:a would be changed to hh:mm:aa.

Fixed behavior:
https://jam.dev/c/151b0854-5c9c-4715-a767-0f515384b3a0

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self review of my code.
- [x] I have updated the documentation / READMEs where necessary.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
