### PR TITLE
ENG-1628: Add support for multiple rules in the UISchema.

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -209,7 +209,7 @@ export interface UISchemaElement {
   /**
    * An optional rule.
    */
-  rule?: Rule;
+  rule?: Rule[] | Rule;
 
   /**
    * Any additional options.

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -56,7 +56,7 @@ import {
   isVisible,
 } from '../util';
 import { JsonSchema } from '../models/jsonSchema';
-import { UISchemaElement, SchemaBasedCondition } from '../models';
+import { UISchemaElement, SchemaBasedCondition, Rule } from '../models';
 
 export const initState: JsonFormsCore = {
   data: {},
@@ -184,7 +184,7 @@ const createDynamicSchema = (
         if (
           !isFieldVisible &&
           data[key] !== undefined &&
-          !control.rule?.options?.preserveValueOnHide
+          !(control.rule as Rule)?.options?.preserveValueOnHide
         ) {
           // Only create a copy if we haven't already
           if (!dataChanged) {


### PR DESCRIPTION
<!--- Provide a one-line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description
 - Add support for multiple different rules in the UISchema. 
 - Adjust render logic so it evaluates the rule as an array.
 - Update type and test added.
 - Make sure this change is backward compatible.
<!--- Describe your changes in detail -->

## Motivation and Context
https://linear.app/avantos/issue/ENG-1628/placeholder-support-separate-conditions-for-different-effect
<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self-review of my code.
- [x] I have updated the documentation / READMEs where necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
