### PR TITLE
ENG-1315: Fix asterisk missing when checkbox is required.

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -517,7 +517,7 @@ export const computeLabel = (
   required: boolean,
   hideRequiredAsterisk: boolean
 ): string => {
-  return `${label ?? ''}${required && !hideRequiredAsterisk ? '*' : ''}`;
+  return `${label ?? ''}${required && !hideRequiredAsterisk ? ' *' : ''}`;
 };
 
 /**

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -2163,7 +2163,7 @@ test('computeLabel - should not edit label if required but hideRequiredAsterisk 
 
 test('computeLabel - should add asterisk if required but hideRequiredAsterisk is false', (t) => {
   const computedLabel = computeLabel('Test Label', true, false);
-  t.is(computedLabel, 'Test Label*');
+  t.is(computedLabel, 'Test Label *');
 });
 
 test('mapStateToAnyOfProps - const constraint in anyOf schema should return correct indexOfFittingSchema', (t) => {

--- a/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
@@ -31,6 +31,7 @@ import {
   rankWith,
   ControlProps,
   isDescriptionHidden,
+  computeLabel,
 } from '@mosaic-avantos/jsonforms-core';
 import { withJsonFormsControlProps } from '@mosaic-avantos/jsonforms-react';
 import { FormControlLabel, FormHelperText, Tooltip } from '@mui/material';
@@ -50,6 +51,7 @@ export const MaterialBooleanControl = ({
   path,
   config,
   description,
+  required,
 }: ControlProps) => {
   const isValid = errors.length === 0;
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
@@ -107,7 +109,11 @@ export const MaterialBooleanControl = ({
     <>
       <Tooltip id={tooltipId} title={showTooltip ? description : ''}>
         <FormControlLabel
-          label={label}
+          label={computeLabel(
+            label,
+            required,
+            appliedUiSchemaOptions.hideRequiredAsterisk
+          )}
           id={id}
           control={
             <MuiCheckbox

--- a/packages/vanilla-renderers/test/renderers/InputControl.test.tsx
+++ b/packages/vanilla-renderers/test/renderers/InputControl.test.tsx
@@ -422,7 +422,7 @@ describe('Input control', () => {
       </JsonFormsStateProvider>
     );
     const label = wrapper.find('label');
-    expect(label.text()).toBe('Date Cell*');
+    expect(label.text()).toBe('Date Cell *');
   });
 
   test('not required', () => {


### PR DESCRIPTION
<!--- Provide a one line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description
- Update the boolean element to show an asterisk when required.
- Showcase: https://jam.dev/c/7a635f8b-6673-4904-860f-e6e377e625c8
<!--- Describe your changes in detail -->

## Motivation and Context
https://linear.app/avantos/issue/ENG-1315/bug-checkbox-component-can-not-be-marked-as-required-and-is-missing
<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self-review of my code.
- [x] I have updated the documentation / READMEs where necessary.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
