### PR TITLE
[ACT-458] Date field validation issue when re-entering the same date

### DIFF
--- a/packages/material-renderers/src/util/datejs.tsx
+++ b/packages/material-renderers/src/util/datejs.tsx
@@ -38,7 +38,8 @@ export const createOnBlurHandler =
       )
     ) {
       handleChange(path, undefined);
-      // don't rerender so user can click the date picker.
+      rerenderChild();
+      // rerender to reset the DatePicker's internal state when field is empty.
     } else if (formatedDate.toString() === 'Invalid Date') {
       handleChange(path, undefined);
       rerenderChild();


### PR DESCRIPTION
<!--- Provide a one line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description

When the field is deleted and becomes empty, the blur handler wasn't calling `rerenderChild()`, so the `DatePicker` component kept its internal state. By incrementing the key prop through `rerenderChild()`, the `DatePicker` fully remounts and recognizes the same date as a new selection.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self review of my code.
- [ ] I have updated the documentation / READMEs where necessary.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
