### PR TITLE
[ACT-1022] Added 'populate' rule

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -97,10 +97,55 @@ export interface Rule {
      */
     value?: any;
     /**
+     * Options for POPULATE effect
+     */
+    populate?: PopulateOptions;
+    /**
      * Whether to preserve the field's value when it becomes hidden
      */
     preserveValueOnHide?: boolean;
   };
+}
+
+export interface PopulateSelectWhereSchema {
+  /**
+   * JSON Schema to match an array element. The first element validating against this schema
+   * will be selected.
+   *
+   * This enables advanced matching like `allOf`/`anyOf`/`oneOf` and regex via `pattern`.
+   * Note: Remember to use `required` to enforce presence of properties you depend on.
+   */
+  schema: JsonSchema;
+}
+
+export type PopulateSelectWhere = PopulateSelectWhereSchema;
+
+export interface PopulateSelectOptions {
+  /**
+   * Selection predicate for arrays. The first matching element will be used.
+   */
+  where: PopulateSelectWhere;
+}
+
+export interface PopulateOptions {
+  /**
+   * JSON Pointer to the source schema property (e.g. "#/properties/addresses").
+   * The value will be resolved from form data using the corresponding data path.
+   */
+  from: string;
+  /**
+   * Optional dotted path to extract from the resolved source value (or selected array element),
+   * e.g. "state" or "address.state".
+   */
+  valuePath?: string;
+  /**
+   * If the source resolves to an array, optionally select a single element before extracting.
+   */
+  select?: PopulateSelectOptions;
+  /**
+   * Whether to overwrite destination when the source changes. Default: true.
+   */
+  overwrite?: boolean;
 }
 
 /**
@@ -135,6 +180,10 @@ export enum RuleEffect {
    * Effect that clears the value of the associated element.
    */
   CLEAR_VALUE = 'CLEAR_VALUE',
+  /**
+   * Effect that populates the value of the associated element from another field.
+   */
+  POPULATE = 'POPULATE',
 }
 
 /**

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -356,13 +356,26 @@ const applyPopulateRules = (
         continue;
       }
 
-      if (!pathAffects(changedPath, fromPath)) {
+      const prevSource = get(prevData, fromPath);
+      const nextSource = get(updatedData, fromPath);
+      const sourceChanged = !isEqual(prevSource, nextSource);
+
+      const conditionNow = evaluateCondition(
+        updatedData,
+        rule.condition,
+        destPath,
+        ajv
+      );
+      const conditionPrev = prevData
+        ? evaluateCondition(prevData, rule.condition, destPath, ajv)
+        : false;
+      const conditionBecameTrue = !conditionPrev && conditionNow;
+
+      if (!pathAffects(changedPath, fromPath) && !conditionBecameTrue) {
         continue;
       }
 
-      const prevSource = get(prevData, fromPath);
-      const nextSource = get(updatedData, fromPath);
-      if (isEqual(prevSource, nextSource)) {
+      if (!sourceChanged && !conditionBecameTrue) {
         continue;
       }
 
@@ -373,6 +386,9 @@ const applyPopulateRules = (
       // If source becomes empty and overwrite is enabled, clear destination
       if (isEmptySourceValue(nextSource)) {
         if (!overwrite) {
+          continue;
+        }
+        if (!sourceChanged) {
           continue;
         }
         if (currentDest === undefined) {
@@ -386,13 +402,7 @@ const applyPopulateRules = (
         continue;
       }
 
-      const conditionFulfilled = evaluateCondition(
-        updatedData,
-        rule.condition,
-        undefined,
-        ajv
-      );
-      if (!conditionFulfilled) {
+      if (!conditionNow) {
         continue;
       }
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -342,22 +342,28 @@ const getDetailBasePaths = (
   changedPath: string,
   data: any
 ): string[] => {
-  const value = get(data, arrayPath);
+  const normalizedArrayPath = normalizePathForCompare(arrayPath);
+  const normalizedChanged = normalizePathForCompare(changedPath);
+  const value = get(data, normalizedArrayPath);
   if (!isArray(value)) {
-    return [arrayPath];
+    return [];
   }
 
-  if (changedPath === arrayPath) {
-    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+  if (normalizedChanged === normalizedArrayPath) {
+    return value.map((_: any, idx: number) => `${normalizedArrayPath}.${idx}`);
   }
 
-  const idx = extractIndexFromPath(changedPath, arrayPath);
+  const idx = extractIndexFromPath(normalizedChanged, normalizedArrayPath);
   if (idx !== null) {
-    return [`${arrayPath}[${idx}]`];
+    return [`${normalizedArrayPath}.${idx}`];
   }
 
-  if (changedPath === '' || changedPath === undefined || changedPath === null) {
-    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+  if (
+    normalizedChanged === '' ||
+    normalizedChanged === undefined ||
+    normalizedChanged === null
+  ) {
+    return value.map((_: any, idx: number) => `${normalizedArrayPath}.${idx}`);
   }
 
   if (
@@ -366,7 +372,7 @@ const getDetailBasePaths = (
       normalizePathForCompare(arrayPath)
     )
   ) {
-    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+    return value.map((_: any, idx: number) => `${normalizedArrayPath}.${idx}`);
   }
 
   return [];

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -28,6 +28,7 @@ import setFp from 'lodash/fp/set';
 import unsetFp from 'lodash/fp/unset';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
+import isArray from 'lodash/isArray';
 import {
   CoreActions,
   INIT,
@@ -54,9 +55,19 @@ import {
   evalValue,
   hasShowRule,
   isVisible,
+  evaluateCondition,
+  iterateSchema,
+  isControlElement,
+  toDataPath,
 } from '../util';
 import { JsonSchema } from '../models/jsonSchema';
-import { UISchemaElement, SchemaBasedCondition, Rule } from '../models';
+import {
+  UISchemaElement,
+  SchemaBasedCondition,
+  Rule,
+  RuleEffect,
+  PopulateOptions,
+} from '../models';
 
 export const initState: JsonFormsCore = {
   data: {},
@@ -229,6 +240,199 @@ const createDynamicSchema = (
   };
 };
 
+const isEmptySourceValue = (value: any): boolean =>
+  value === undefined || value === null || value === '';
+
+const pathAffects = (changedPath: string, targetPath: string): boolean => {
+  if (changedPath === '' || targetPath === '') {
+    return true;
+  }
+  if (!changedPath || !targetPath) {
+    return false;
+  }
+  const boundaryOk = (full: string, prefix: string) => {
+    if (full.length === prefix.length) return true;
+    const next = full.charAt(prefix.length);
+    return next === '.' || next === '[';
+  };
+  return (
+    (changedPath.startsWith(targetPath) &&
+      boundaryOk(changedPath, targetPath)) ||
+    (targetPath.startsWith(changedPath) && boundaryOk(targetPath, changedPath))
+  );
+};
+
+const computePopulateValue = (
+  sourceValue: any,
+  options: PopulateOptions,
+  ajv: Ajv
+): { shouldSet: boolean; newValue: any } => {
+  if (isEmptySourceValue(sourceValue)) {
+    return { shouldSet: false, newValue: undefined };
+  }
+
+  let base: any = sourceValue;
+
+  if (options.select) {
+    if (!isArray(base)) {
+      return { shouldSet: false, newValue: undefined };
+    }
+    const where = options.select.where;
+    if (!where) {
+      return { shouldSet: false, newValue: undefined };
+    }
+
+    const match = (base as any[]).find((el) => {
+      try {
+        return ajv.validate(where.schema, el) as boolean;
+      } catch (e) {
+        // Invalid schema or validation error -> no match
+        return false;
+      }
+    });
+    if (match === undefined) {
+      return { shouldSet: false, newValue: undefined };
+    }
+    base = match;
+  }
+
+  if (options.valuePath && options.valuePath.length > 0) {
+    const extracted = get(base, options.valuePath);
+    if (extracted === undefined) {
+      return { shouldSet: false, newValue: undefined };
+    }
+    return { shouldSet: true, newValue: extracted };
+  }
+
+  return { shouldSet: true, newValue: base };
+};
+
+const applyPopulateRules = (
+  prevData: any,
+  nextData: any,
+  uischema: UISchemaElement,
+  changedPath: string,
+  ajv: Ajv
+): any => {
+  if (!uischema || changedPath === undefined || changedPath === null) {
+    return nextData;
+  }
+
+  let updatedData = nextData;
+  let dataChanged = false;
+
+  iterateSchema(uischema, (el) => {
+    if (!isControlElement(el)) {
+      return;
+    }
+    const control: any = el;
+    const rules: Rule[] = Array.isArray(control.rule)
+      ? control.rule
+      : control.rule
+      ? [control.rule]
+      : [];
+
+    if (rules.length === 0) {
+      return;
+    }
+
+    const destPath = control.scope ? toDataPath(control.scope) : '';
+    if (!destPath) {
+      return;
+    }
+
+    for (const rule of rules) {
+      const effects = Array.isArray(rule.effect) ? rule.effect : [rule.effect];
+      if (!effects.includes(RuleEffect.POPULATE)) {
+        continue;
+      }
+      const pop: PopulateOptions | undefined = rule.options?.populate;
+      if (!pop?.from) {
+        continue;
+      }
+
+      const fromPath = toDataPath(pop.from);
+      if (!fromPath) {
+        continue;
+      }
+
+      if (!pathAffects(changedPath, fromPath)) {
+        continue;
+      }
+
+      const prevSource = get(prevData, fromPath);
+      const nextSource = get(updatedData, fromPath);
+      if (isEqual(prevSource, nextSource)) {
+        continue;
+      }
+
+      const currentDest = get(updatedData, destPath);
+
+      const overwrite = pop.overwrite !== undefined ? pop.overwrite : true;
+
+      // If source becomes empty and overwrite is enabled, clear destination
+      if (isEmptySourceValue(nextSource)) {
+        if (!overwrite) {
+          continue;
+        }
+        if (currentDest === undefined) {
+          continue;
+        }
+        if (!dataChanged) {
+          updatedData = cloneDeep(updatedData);
+          dataChanged = true;
+        }
+        updatedData = unsetFp(destPath, updatedData);
+        continue;
+      }
+
+      const conditionFulfilled = evaluateCondition(
+        updatedData,
+        rule.condition,
+        undefined,
+        ajv
+      );
+      if (!conditionFulfilled) {
+        continue;
+      }
+
+      const { shouldSet, newValue } = computePopulateValue(
+        nextSource,
+        {
+          overwrite: true,
+          ...pop,
+        },
+        ajv
+      );
+      if (!shouldSet) {
+        continue;
+      }
+
+      const destIsEmpty = isEmptySourceValue(currentDest);
+      if (!overwrite && !destIsEmpty) {
+        continue;
+      }
+
+      if (isEqual(currentDest, newValue)) {
+        continue;
+      }
+
+      if (!dataChanged) {
+        updatedData = cloneDeep(updatedData);
+        dataChanged = true;
+      }
+
+      if (newValue === undefined) {
+        updatedData = unsetFp(destPath, updatedData);
+      } else {
+        updatedData = setFp(destPath, newValue, updatedData);
+      }
+    }
+  });
+
+  return updatedData;
+};
+
 export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
   state = initState,
   action
@@ -238,11 +442,19 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
       const thisAjv = getOrCreateAjv(state, action);
       const validationMode = getValidationMode(state, action);
 
+      const populatedData = applyPopulateRules(
+        undefined,
+        action.data,
+        action.uischema,
+        '',
+        thisAjv
+      );
+
       // Create dynamic schema with UI-based required fields
       const { schema: dynamicSchema, updatedData } = createDynamicSchema(
         action.schema,
         action.uischema,
-        action.data,
+        populatedData,
         thisAjv
       );
 
@@ -271,11 +483,19 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
       let validator = state.validator;
       let errors = state.errors;
 
+      const populatedData = applyPopulateRules(
+        state.data,
+        action.data,
+        action.uischema,
+        '',
+        thisAjv
+      );
+
       // Create dynamic schema with UI-based required fields
       const { schema: dynamicSchema, updatedData } = createDynamicSchema(
         action.schema,
         action.uischema,
-        action.data,
+        populatedData,
         thisAjv
       );
 
@@ -369,12 +589,19 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
       } else if (action.path === '') {
         // empty path is ok
         const result = action.updater(cloneDeep(state.data));
+        const populated = applyPopulateRules(
+          state.data,
+          result,
+          state.uischema,
+          '',
+          state.ajv
+        );
 
         // Create dynamic schema with UI-based required fields and clear hidden fields
         const { schema: dynamicSchema, updatedData } = createDynamicSchema(
           state.schema,
           state.uischema,
-          result,
+          populated,
           state.ajv
         );
 
@@ -402,12 +629,19 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
             state.data === undefined ? {} : state.data
           );
         }
+        const populated = applyPopulateRules(
+          state.data,
+          newState,
+          state.uischema,
+          action.path,
+          state.ajv
+        );
 
         // Create dynamic schema with UI-based required fields and clear hidden fields
         const { schema: dynamicSchema, updatedData } = createDynamicSchema(
           state.schema,
           state.uischema,
-          newState,
+          populated,
           state.ajv
         );
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -56,8 +56,9 @@ import {
   hasShowRule,
   isVisible,
   evaluateCondition,
-  iterateSchema,
   isControlElement,
+  isLayout,
+  composePaths,
   toDataPath,
 } from '../util';
 import { JsonSchema } from '../models/jsonSchema';
@@ -307,6 +308,70 @@ const computePopulateValue = (
   return { shouldSet: true, newValue: base };
 };
 
+const getParentPath = (path: string): string => {
+  if (!path) {
+    return '';
+  }
+  const lastDot = path.lastIndexOf('.');
+  return lastDot === -1 ? '' : path.slice(0, lastDot);
+};
+
+const normalizePathForCompare = (path: string): string =>
+  path ? path.replace(/\[(\d+)\]/g, '.$1') : path;
+
+const extractIndexFromPath = (
+  changedPath: string,
+  arrayPath: string
+): number | null => {
+  if (!changedPath || !arrayPath) {
+    return null;
+  }
+  const normalizedChanged = normalizePathForCompare(changedPath);
+  const normalizedArray = normalizePathForCompare(arrayPath);
+  if (!normalizedChanged.startsWith(`${normalizedArray}.`)) {
+    return null;
+  }
+  const rest = normalizedChanged.slice(normalizedArray.length + 1);
+  const idxStr = rest.split('.')[0];
+  const idx = Number(idxStr);
+  return Number.isInteger(idx) ? idx : null;
+};
+
+const getDetailBasePaths = (
+  arrayPath: string,
+  changedPath: string,
+  data: any
+): string[] => {
+  const value = get(data, arrayPath);
+  if (!isArray(value)) {
+    return [arrayPath];
+  }
+
+  if (changedPath === arrayPath) {
+    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+  }
+
+  const idx = extractIndexFromPath(changedPath, arrayPath);
+  if (idx !== null) {
+    return [`${arrayPath}[${idx}]`];
+  }
+
+  if (changedPath === '' || changedPath === undefined || changedPath === null) {
+    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+  }
+
+  if (
+    pathAffects(
+      normalizePathForCompare(changedPath),
+      normalizePathForCompare(arrayPath)
+    )
+  ) {
+    return value.map((_: any, idx: number) => `${arrayPath}[${idx}]`);
+  }
+
+  return [];
+};
+
 const applyPopulateRules = (
   prevData: any,
   nextData: any,
@@ -321,11 +386,7 @@ const applyPopulateRules = (
   let updatedData = nextData;
   let dataChanged = false;
 
-  iterateSchema(uischema, (el) => {
-    if (!isControlElement(el)) {
-      return;
-    }
-    const control: any = el;
+  const applyToControl = (control: any, basePath: string) => {
     const rules: Rule[] = Array.isArray(control.rule)
       ? control.rule
       : control.rule
@@ -336,10 +397,21 @@ const applyPopulateRules = (
       return;
     }
 
-    const destPath = control.scope ? toDataPath(control.scope) : '';
+    const localDestPath = control.scope ? toDataPath(control.scope) : '';
+    const destPath =
+      localDestPath && basePath
+        ? composePaths(basePath, localDestPath)
+        : basePath || localDestPath;
     if (!destPath) {
       return;
     }
+    const conditionBasePath = (() => {
+      const parentPath = getParentPath(localDestPath);
+      if (!parentPath) {
+        return basePath;
+      }
+      return basePath ? composePaths(basePath, parentPath) : parentPath;
+    })();
 
     for (const rule of rules) {
       const effects = Array.isArray(rule.effect) ? rule.effect : [rule.effect];
@@ -351,7 +423,11 @@ const applyPopulateRules = (
         continue;
       }
 
-      const fromPath = toDataPath(pop.from);
+      const localFromPath = toDataPath(pop.from);
+      const fromPath =
+        localFromPath && basePath
+          ? composePaths(basePath, localFromPath)
+          : basePath || localFromPath;
       if (!fromPath) {
         continue;
       }
@@ -363,15 +439,21 @@ const applyPopulateRules = (
       const conditionNow = evaluateCondition(
         updatedData,
         rule.condition,
-        destPath,
+        conditionBasePath,
         ajv
       );
       const conditionPrev = prevData
-        ? evaluateCondition(prevData, rule.condition, destPath, ajv)
+        ? evaluateCondition(prevData, rule.condition, conditionBasePath, ajv)
         : false;
       const conditionBecameTrue = !conditionPrev && conditionNow;
 
-      if (!pathAffects(changedPath, fromPath) && !conditionBecameTrue) {
+      if (
+        !pathAffects(
+          normalizePathForCompare(changedPath),
+          normalizePathForCompare(fromPath)
+        ) &&
+        !conditionBecameTrue
+      ) {
         continue;
       }
 
@@ -438,7 +520,44 @@ const applyPopulateRules = (
         updatedData = setFp(destPath, newValue, updatedData);
       }
     }
-  });
+  };
+
+  const traverse = (element: UISchemaElement, basePath: string) => {
+    if (isLayout(element)) {
+      if (Array.isArray(element.elements)) {
+        element.elements.forEach((child) => traverse(child, basePath));
+      }
+      return;
+    }
+    if (!isControlElement(element)) {
+      return;
+    }
+
+    const control: any = element;
+    applyToControl(control, basePath);
+
+    const detail = control.options?.detail;
+    if (detail) {
+      const controlPath = control.scope ? toDataPath(control.scope) : '';
+      const arrayPath =
+        controlPath && basePath
+          ? composePaths(basePath, controlPath)
+          : basePath || controlPath;
+
+      if (!arrayPath) {
+        return;
+      }
+
+      const detailPaths = getDetailBasePaths(
+        arrayPath,
+        changedPath,
+        updatedData
+      );
+      detailPaths.forEach((detailPath) => traverse(detail, detailPath));
+    }
+  };
+
+  traverse(uischema, '');
 
   return updatedData;
 };

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -50,7 +50,18 @@ export const resolveData = (instance: any, dataPath: string): any => {
   if (isEmpty(dataPath)) {
     return instance;
   }
-  return get(instance, dataPath);
+  const dataPathSegments = dataPath.split('.');
+
+  return dataPathSegments.reduce((curInstance, decodedSegment) => {
+    if (
+      !curInstance ||
+      !Object.prototype.hasOwnProperty.call(curInstance, decodedSegment)
+    ) {
+      return undefined;
+    }
+
+    return curInstance[decodedSegment];
+  }, instance);
 };
 
 /**

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -50,18 +50,7 @@ export const resolveData = (instance: any, dataPath: string): any => {
   if (isEmpty(dataPath)) {
     return instance;
   }
-  const dataPathSegments = dataPath.split('.');
-
-  return dataPathSegments.reduce((curInstance, decodedSegment) => {
-    if (
-      !curInstance ||
-      !Object.prototype.hasOwnProperty.call(curInstance, decodedSegment)
-    ) {
-      return undefined;
-    }
-
-    return curInstance[decodedSegment];
-  }, instance);
+  return get(instance, dataPath);
 };
 
 /**

--- a/packages/core/src/util/runtime.ts
+++ b/packages/core/src/util/runtime.ts
@@ -62,7 +62,7 @@ const getConditionScope = (condition: Scopable, path: string): string => {
   return composeWithUi(condition, path);
 };
 
-const evaluateCondition = (
+export const evaluateCondition = (
   data: any,
   condition: Condition,
   path: string,
@@ -100,7 +100,7 @@ const EFFECT_GROUPS = {
   VISIBILITY: [RuleEffect.SHOW, RuleEffect.HIDE],
   ENABLEMENT: [RuleEffect.ENABLE, RuleEffect.DISABLE],
   REQUIREMENT: [RuleEffect.REQUIRED],
-  VALUE: [RuleEffect.FILL_VALUE, RuleEffect.CLEAR_VALUE],
+  VALUE: [RuleEffect.FILL_VALUE, RuleEffect.CLEAR_VALUE, RuleEffect.POPULATE],
 };
 
 // Check if two effects are compatible (not in the same group)
@@ -268,6 +268,12 @@ export const hasValueRule = (uischema: UISchemaElement): boolean => {
     getEffects(rule).some((effect) =>
       [RuleEffect.FILL_VALUE, RuleEffect.CLEAR_VALUE].includes(effect)
     )
+  );
+};
+
+export const hasPopulateRule = (uischema: UISchemaElement): boolean => {
+  return normalizeRules(uischema.rule).some((rule) =>
+    getEffects(rule).some((effect) => effect === RuleEffect.POPULATE)
   );
 };
 

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -3411,3 +3411,155 @@ test('core reducer - POPULATE chained destinations work on updateCore (ordering 
   t.is(updatedState.data.dest1, 'b');
   t.is(updatedState.data.dest2, 'b');
 });
+
+test('core reducer - POPULATE chained destinations do not update on update path', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest1: { type: 'string' },
+      dest2: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest1',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/source', overwrite: true },
+          },
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/dest2',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/dest1', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest1: '', dest2: '' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    update('source', () => 'b')
+  );
+
+  t.is(updatedState.data.dest1, 'b');
+  t.is(updatedState.data.dest2, '');
+});
+
+test('core reducer - POPULATE applies when condition toggles true (update path)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+      flag: { type: 'boolean' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { from: '#/properties/source', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: '', flag: false }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    update('flag', () => true)
+  );
+
+  t.is(updatedState.data.dest, 'a');
+});
+
+test('core reducer - POPULATE condition scopes resolve relative to control path', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      address: {
+        type: 'object',
+        properties: {
+          country: { type: 'string' },
+          source: { type: 'string' },
+          state: { type: 'string' },
+        },
+      },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/address/properties/country' },
+      { type: 'Control', scope: '#/properties/address/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/address/properties/state',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/country',
+            expectedValue: 'US',
+          },
+          options: {
+            populate: {
+              from: '#/properties/address/properties/source',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(
+    undefined,
+    init(
+      { address: { country: 'US', source: 'NY', state: '' } },
+      schema,
+      uischema
+    )
+  );
+
+  t.is(state.data.address.state, 'NY');
+});

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -3632,7 +3632,7 @@ test('core reducer - POPULATE traverses options.detail for array elements', (t) 
 
   const updatedState = coreReducer(
     initialState,
-    update('addresses[0].flag', () => true)
+    update('addresses.0.flag', () => true)
   );
 
   t.is(updatedState.data.addresses[0].dest, 'a');

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -3453,7 +3453,7 @@ test('core reducer - POPULATE chained destinations do not update on update path'
 
   const initialState = coreReducer(
     undefined,
-    init({ source: 'a', dest1: '', dest2: '' }, schema, uischema)
+    init({ source: '', dest1: '', dest2: '' }, schema, uischema)
   );
 
   const updatedState = coreReducer(
@@ -3562,4 +3562,152 @@ test('core reducer - POPULATE condition scopes resolve relative to control path'
   );
 
   t.is(state.data.address.state, 'NY');
+});
+
+test('core reducer - POPULATE traverses options.detail for array elements', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            source: { type: 'string' },
+            dest: { type: 'string' },
+            flag: { type: 'boolean' },
+          },
+        },
+      },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/addresses',
+        options: {
+          detail: {
+            type: 'VerticalLayout',
+            elements: [
+              { type: 'Control', scope: '#/properties/source' },
+              { type: 'Control', scope: '#/properties/flag' },
+              {
+                type: 'Control',
+                scope: '#/properties/dest',
+                rule: {
+                  effect: 'POPULATE',
+                  condition: {
+                    type: 'LEAF',
+                    scope: '#/properties/flag',
+                    expectedValue: true,
+                  },
+                  options: {
+                    populate: {
+                      from: '#/properties/source',
+                      overwrite: true,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [{ source: 'a', dest: '', flag: false }],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    update('addresses[0].flag', () => true)
+  );
+
+  t.is(updatedState.data.addresses[0].dest, 'a');
+});
+
+test('core reducer - POPULATE updates row on source change with dot index path', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            source: { type: 'string' },
+            dest: { type: 'string' },
+            flag: { type: 'boolean' },
+          },
+        },
+      },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/addresses',
+        options: {
+          detail: {
+            type: 'VerticalLayout',
+            elements: [
+              { type: 'Control', scope: '#/properties/source' },
+              { type: 'Control', scope: '#/properties/flag' },
+              {
+                type: 'Control',
+                scope: '#/properties/dest',
+                rule: {
+                  effect: 'POPULATE',
+                  condition: {
+                    type: 'LEAF',
+                    scope: '#/properties/flag',
+                    expectedValue: true,
+                  },
+                  options: {
+                    populate: {
+                      from: '#/properties/source',
+                      overwrite: true,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [{ source: '', dest: '', flag: true }],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    update('addresses.0.source', () => 'test')
+  );
+
+  t.is(updatedState.data.addresses[0].dest, 'test');
 });

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -2626,3 +2626,788 @@ test('Default values should be cleared in schema when preserveValueOnHide is fal
     'shortText default should be cleared from schema when preserveValueOnHide is false'
   );
 });
+
+test('core reducer - POPULATE rule populates destination from scalar source when the source changes', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: {
+              type: 'object',
+              required: ['source'],
+            },
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: '' }, schema, uischema)
+  );
+
+  // change source -> should populate dest
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: 'b' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest, 'b');
+});
+
+test('core reducer - POPULATE rule no-ops when extracted value is missing', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      address: { type: 'object' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/dest' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: {
+              type: 'object',
+              required: ['address'],
+            },
+          },
+          options: {
+            populate: {
+              from: '#/properties/address',
+              valuePath: 'state',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ address: {}, dest: 'keep' }, schema, uischema)
+  );
+
+  // update address (still missing state) -> should keep dest unchanged
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      { ...initialState.data, address: { type: 'mailing' } },
+      schema,
+      uischema
+    )
+  );
+
+  t.is(updatedState.data.dest, 'keep');
+});
+
+test('core reducer - POPULATE rule selects from array via schema and extracts valuePath', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: { type: 'array' },
+      mailingState: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/addresses' },
+      {
+        type: 'Control',
+        scope: '#/properties/mailingState',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: {
+              type: 'object',
+              required: ['addresses'],
+            },
+          },
+          options: {
+            populate: {
+              from: '#/properties/addresses',
+              select: {
+                where: {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      type: { const: 'mailing' },
+                    },
+                    required: ['type'],
+                  },
+                },
+              },
+              valuePath: 'state',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [{ type: 'home', state: 'CA' }],
+        mailingState: '',
+      },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialState.data,
+        addresses: [
+          { type: 'home', state: 'CA' },
+          { type: 'mailing', state: 'NY' },
+        ],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  t.is(updatedState.data.mailingState, 'NY');
+});
+
+test('core reducer - POPULATE rule selects from array via schema (supports pattern/regex)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: { type: 'array' },
+      selectedState: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/addresses' },
+      {
+        type: 'Control',
+        scope: '#/properties/selectedState',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object', required: ['addresses'] },
+          },
+          options: {
+            populate: {
+              from: '#/properties/addresses',
+              select: {
+                where: {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      type: { const: 'mailing' },
+                      state: { type: 'string', pattern: '^N(J|Y)$' },
+                    },
+                    required: ['type', 'state'],
+                  },
+                },
+              },
+              valuePath: 'state',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [
+          { type: 'mailing', state: 'CA' },
+          { type: 'home', state: 'NJ' },
+        ],
+        selectedState: '',
+      },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialState.data,
+        addresses: [
+          { type: 'mailing', state: 'CA' },
+          { type: 'mailing', state: 'NJ' },
+          { type: 'mailing', state: 'NY' },
+        ],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  // first match should win => NJ (matches pattern), not NY
+  t.is(updatedState.data.selectedState, 'NJ');
+});
+
+test('core reducer - POPULATE rule with overwrite=false does not override existing value', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/source',
+            expectedValue: 'b',
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: false,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: 'user' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: 'b' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest, 'user');
+});
+
+test('core reducer - POPULATE rule clears destination when source becomes empty (implied by overwrite=true)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object' },
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: 'a' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: '' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest, undefined);
+});
+
+test('core reducer - POPULATE clears even when condition would not be fulfilled for empty source (implied by overwrite=true)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: {
+              type: 'object',
+              required: ['source'],
+            },
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: 'a' }, schema, uischema)
+  );
+
+  // When source becomes empty, the condition (required: ['source']) would fail.
+  // Even though the condition would fail, we still expect the destination to be cleared (overwrite implied).
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: '' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest, undefined);
+});
+
+test('core reducer - POPULATE with overwrite=false does not clear destination when source becomes empty', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object' },
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: false,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest: 'keep' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: '' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest, 'keep');
+});
+
+test('core reducer - POPULATE supports nested destination scope (foo.bar)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      foo: {
+        type: 'object',
+        properties: {
+          bar: { type: 'string' },
+        },
+      },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/foo/properties/bar',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object' },
+          },
+          options: {
+            populate: {
+              from: '#/properties/source',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', foo: { bar: '' } }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: 'b' }, schema, uischema)
+  );
+  t.is(updatedState.data.foo.bar, 'b');
+
+  const clearedState = coreReducer(
+    updatedState,
+    updateCore({ ...updatedState.data, source: '' }, schema, uischema)
+  );
+  t.is(clearedState.data.foo.bar, undefined);
+});
+
+test('core reducer - POPULATE schema selector supports anyOf', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: { type: 'array' },
+      selectedState: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/addresses' },
+      {
+        type: 'Control',
+        scope: '#/properties/selectedState',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object', required: ['addresses'] },
+          },
+          options: {
+            populate: {
+              from: '#/properties/addresses',
+              select: {
+                where: {
+                  schema: {
+                    anyOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          type: { const: 'mailing' },
+                          state: { const: 'NJ' },
+                        },
+                        required: ['type', 'state'],
+                      },
+                      {
+                        type: 'object',
+                        properties: {
+                          type: { const: 'home' },
+                          state: { const: 'CA' },
+                        },
+                        required: ['type', 'state'],
+                      },
+                    ],
+                  },
+                },
+              },
+              valuePath: 'state',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [
+          { type: 'mailing', state: 'CA' },
+          { type: 'home', state: 'CA' },
+        ],
+        selectedState: '',
+      },
+      schema,
+      uischema
+    )
+  );
+
+  // Should select the first element matching anyOf: home+CA, thus state "CA"
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialState.data,
+        addresses: [
+          { type: 'home', state: 'CA' },
+          { type: 'mailing', state: 'NJ' },
+        ],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  t.is(updatedState.data.selectedState, 'CA');
+});
+
+test('core reducer - POPULATE no-ops when selector schema is invalid', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: { type: 'array' },
+      selectedState: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/addresses' },
+      {
+        type: 'Control',
+        scope: '#/properties/selectedState',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            scope: '#',
+            schema: { type: 'object', required: ['addresses'] },
+          },
+          options: {
+            populate: {
+              from: '#/properties/addresses',
+              select: {
+                where: {
+                  // invalid regex pattern -> AJV throws during validate/compile
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      state: { type: 'string', pattern: '[' },
+                    },
+                    required: ['state'],
+                  },
+                },
+              },
+              valuePath: 'state',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        addresses: [{ type: 'mailing', state: 'NJ' }],
+        selectedState: 'keep',
+      },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore(
+      {
+        ...initialState.data,
+        addresses: [{ type: 'mailing', state: 'NY' }],
+      },
+      schema,
+      uischema
+    )
+  );
+
+  // Invalid selector schema => no match => no update
+  t.is(updatedState.data.selectedState, 'keep');
+});
+
+test('core reducer - POPULATE applies to multiple destinations from the same source', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest1: { type: 'string' },
+      dest2: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest1',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/source', overwrite: true },
+          },
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/dest2',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/source', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest1: '', dest2: '' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: 'b' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest1, 'b');
+  t.is(updatedState.data.dest2, 'b');
+});
+
+test('core reducer - POPULATE chained destinations work on updateCore (ordering within one pass)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      source: { type: 'string' },
+      dest1: { type: 'string' },
+      dest2: { type: 'string' },
+    },
+  };
+
+  // dest1 populated from source; dest2 populated from dest1
+  // This works with updateCore because applyPopulateRules is invoked with changedPath '' (treat as full update),
+  // allowing all populate rules to be considered within the same pass.
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/source' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest1',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/source', overwrite: true },
+          },
+        },
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/dest2',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/dest1', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ source: 'a', dest1: '', dest2: '' }, schema, uischema)
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    updateCore({ ...initialState.data, source: 'b' }, schema, uischema)
+  );
+
+  t.is(updatedState.data.dest1, 'b');
+  t.is(updatedState.data.dest2, 'b');
+});


### PR DESCRIPTION
<!--- Provide a one line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description

<!--- Describe your changes in detail -->
Added 'populate' rules to JSON Forms to allow one field to be populated from another based on some conditions.

## POPULATE Rule Structure

```json
{
  "rule": {
    "effect": "POPULATE",
    "condition": { ... },
    "options": { "populate": { ... } }
  }
}

```

### `effect`

Always set to `POPULATE`.

### `condition`

When the rule applies. There are two common forms:

**Leaf condition (simple equality)**

```json
{
  "type": "LEAF",
  "scope": "#/properties/status",
  "expectedValue": "active"
}

```

**Schema condition (JSON Schema validation)**

```json
{
  "scope": "#/properties/address",
  "schema": {
    "type": "object",
    "required": ["state"]
  }
}

```

Notes:

- `scope: "#"` evaluates the condition against the root data object.
- In array `options.detail`, scopes like `#/properties/field` are relative to
the row object.

### `options.populate`

```json
{
  "populate": {
    "from": "#/properties/sourceField",
    "valuePath": "nested.path",
    "select": {
      "where": {
        "schema": { ... }
      }
    },
    "overwrite": true
  }
}

```

- `from`: JSON Pointer to the source schema property
- `valuePath`: optional dotted path to extract from the source value
- `select`: optional selector for array sources (first matching element wins)
    - Ex. If addresses is an array, it finds the first element matching the schema (e.g., { "type": "mailing" }) and then uses that element’s state:
    
    ```
    "populate": {
      "from": "#/properties/addresses",
      "select": {
        "where": {
          "schema": {
            "type": "object",
            "properties": { "type": { "const": "mailing" } },
            "required": ["type"]
          }
        }
      },
      "valuePath": "state"
    }
    ```
    
- `overwrite`: whether to overwrite destination (default `true`)

## Flow

1. **Reducer entry**: `applyPopulateRules` runs on `INIT`, `UPDATE_CORE`, and
   `UPDATE_DATA`.
2. **Traverse UI schema**: Walks the UI schema tree and enters `options.detail`
   for array controls, creating a row base path (e.g., `rows.0`).
3. **Resolve paths**:
   - Destination path from the control’s `scope`
   - Source path from `options.populate.from`
4. **Evaluate condition** relative to the control’s parent object path.
5. **Decide to apply**:
   - Source changed **or**
   - Condition became true (compared to previous data)
6. **Compute value**:
   - If `select` is present, choose the first matching array element
   - If `valuePath` is present, extract that nested value
   - Otherwise, use the source value
7. **Write result**:
   - Skip if `overwrite: false` and destination already has a value
   - Set or clear the destination



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self review of my code.
- [ ] I have updated the documentation / READMEs where necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
