### PR TITLE
Populate Rule Fixes and Updates

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -127,12 +127,7 @@ export interface PopulateSelectOptions {
   where: PopulateSelectWhere;
 }
 
-export interface PopulateOptions {
-  /**
-   * JSON Pointer to the source schema property (e.g. "#/properties/addresses").
-   * The value will be resolved from form data using the corresponding data path.
-   */
-  from: string;
+interface PopulateOptionsBase {
   /**
    * Optional dotted path to extract from the resolved source value (or selected array element),
    * e.g. "state" or "address.state".
@@ -147,6 +142,31 @@ export interface PopulateOptions {
    */
   overwrite?: boolean;
 }
+
+interface PopulateFromField extends PopulateOptionsBase {
+  /**
+   * JSON Pointer to the source schema property (e.g. "#/properties/addresses").
+   * The value will be resolved from form data using the corresponding data path.
+   */
+  from: string;
+  value?: never;
+}
+
+interface PopulateFromValue extends PopulateOptionsBase {
+  /**
+   * Hardcoded source value. When present, the destination is populated from this
+   * value instead of form data.
+   */
+  value: any;
+  from?: never;
+}
+
+/**
+ * Options for the POPULATE rule effect. Exactly one of `from` or `value` must be
+ * provided: use `from` to populate from a form field, or `value` for a hardcoded
+ * literal.
+ */
+export type PopulateOptions = PopulateFromField | PopulateFromValue;
 
 /**
  * The different rule effects.

--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -127,12 +127,23 @@ export interface PopulateSelectOptions {
   where: PopulateSelectWhere;
 }
 
+export type PopulateTransform =
+  | { type: 'capitalizeFirst' }
+  | { type: 'firstChar' }
+  | { type: 'last4' }
+  | { type: 'dateOnly' };
+
 interface PopulateOptionsBase {
   /**
    * Optional dotted path to extract from the resolved source value (or selected array element),
    * e.g. "state" or "address.state".
    */
   valuePath?: string;
+  /**
+   * Optional transforms to apply to the resolved value after `select` + `valuePath`.
+   * Applied in order.
+   */
+  transforms?: PopulateTransform[];
   /**
    * If the source resolves to an array, optionally select a single element before extracting.
    */

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -267,7 +267,7 @@ const computePopulateValue = (
   sourceValue: any,
   options: PopulateOptions,
   ajv: Ajv
-): { shouldSet: boolean; newValue: any } => {
+): { shouldSet: boolean; newValue: any; selectNoMatch?: boolean } => {
   if (isEmptySourceValue(sourceValue)) {
     return { shouldSet: false, newValue: undefined };
   }
@@ -283,16 +283,21 @@ const computePopulateValue = (
       return { shouldSet: false, newValue: undefined };
     }
 
-    const match = (base as any[]).find((el) => {
-      try {
-        return ajv.validate(where.schema, el) as boolean;
-      } catch (_error) {
-        // Invalid schema or validation error -> no match
-        return false;
-      }
-    });
-    if (match === undefined) {
+    let match: any;
+    try {
+      match = (base as any[]).find(
+        (el) => ajv.validate(where.schema, el) as boolean
+      );
+    } catch (_error) {
+      // Invalid schema or validation error -> no-op, don't clear destination
       return { shouldSet: false, newValue: undefined };
+    }
+    if (match === undefined) {
+      return {
+        shouldSet: false,
+        newValue: undefined,
+        selectNoMatch: true,
+      };
     }
     base = match;
   }
@@ -512,7 +517,7 @@ const applyPopulateRules = (
         continue;
       }
 
-      const { shouldSet, newValue } = computePopulateValue(
+      const { shouldSet, newValue, selectNoMatch } = computePopulateValue(
         nextSource,
         {
           overwrite: true,
@@ -521,6 +526,15 @@ const applyPopulateRules = (
         ajv
       );
       if (!shouldSet) {
+        // Select found no matching element - clear destination when overwrite is true.
+        // Don't clear for valuePath missing or invalid schema (selectNoMatch is not set).
+        if (selectNoMatch && overwrite && currentDest !== undefined) {
+          if (!dataChanged) {
+            updatedData = cloneDeep(updatedData);
+            dataChanged = true;
+          }
+          updatedData = unsetFp(destPath, updatedData);
+        }
         continue;
       }
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -430,21 +430,36 @@ const applyPopulateRules = (
         continue;
       }
       const pop: PopulateOptions | undefined = rule.options?.populate;
-      if (!pop?.from) {
+      if (!pop) {
+        continue;
+      }
+      const hasFrom = pop.from != null && pop.from !== '';
+      const hasValue = pop.value !== undefined;
+      if ((hasFrom && hasValue) || (!hasFrom && !hasValue)) {
         continue;
       }
 
-      const localFromPath = toDataPath(pop.from);
-      const fromPath =
-        localFromPath && basePath
-          ? composePaths(basePath, localFromPath)
-          : basePath || localFromPath;
-      if (!fromPath) {
-        continue;
+      let prevSource: any;
+      let nextSource: any;
+      let fromPath: string | undefined;
+
+      if (hasValue && !hasFrom) {
+        prevSource = prevData === undefined ? undefined : pop.value;
+        nextSource = pop.value;
+        fromPath = '';
+      } else {
+        const localFromPath = toDataPath(pop.from!);
+        fromPath =
+          localFromPath && basePath
+            ? composePaths(basePath, localFromPath)
+            : basePath || localFromPath;
+        if (!fromPath) {
+          continue;
+        }
+        prevSource = get(prevData, fromPath);
+        nextSource = get(updatedData, fromPath);
       }
 
-      const prevSource = get(prevData, fromPath);
-      const nextSource = get(updatedData, fromPath);
       const sourceChanged = !isEqual(prevSource, nextSource);
 
       const conditionNow = evaluateCondition(
@@ -470,7 +485,12 @@ const applyPopulateRules = (
         continue;
       }
 
-      if (!sourceChanged && !conditionBecameTrue && !conditionBecameFalse) {
+      if (
+        !sourceChanged &&
+        !conditionBecameTrue &&
+        !conditionBecameFalse &&
+        !hasValue
+      ) {
         continue;
       }
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -68,6 +68,7 @@ import {
   Rule,
   RuleEffect,
   PopulateOptions,
+  PopulateTransform,
 } from '../models';
 
 export const initState: JsonFormsCore = {
@@ -307,10 +308,71 @@ const computePopulateValue = (
     if (extracted === undefined) {
       return { shouldSet: false, newValue: undefined };
     }
-    return { shouldSet: true, newValue: extracted };
+    return {
+      shouldSet: true,
+      newValue: applyPopulateTransforms(extracted, options.transforms),
+    };
   }
 
-  return { shouldSet: true, newValue: base };
+  return {
+    shouldSet: true,
+    newValue: applyPopulateTransforms(base, options.transforms),
+  };
+};
+
+const applyPopulateTransforms = (
+  value: any,
+  transforms?: PopulateTransform[]
+): any => {
+  if (!transforms || transforms.length === 0) {
+    return value;
+  }
+
+  let current = value;
+
+  for (const t of transforms) {
+    if (t.type === 'dateOnly') {
+      if (current instanceof Date) {
+        current = current.toISOString().slice(0, 10);
+        continue;
+      }
+      if (typeof current === 'string') {
+        if (current.includes('T')) {
+          current = current.split('T')[0];
+          continue;
+        }
+        const parsed = new Date(current);
+        if (!Number.isNaN(parsed.getTime())) {
+          current = parsed.toISOString().slice(0, 10);
+        }
+      }
+      continue;
+    }
+
+    if (typeof current !== 'string') {
+      continue;
+    }
+
+    if (t.type === 'capitalizeFirst') {
+      current =
+        current.length === 0
+          ? current
+          : current.charAt(0).toUpperCase() + current.slice(1);
+      continue;
+    }
+
+    if (t.type === 'firstChar') {
+      current = current.length === 0 ? current : current.charAt(0);
+      continue;
+    }
+
+    if (t.type === 'last4') {
+      current = current.length <= 4 ? current : current.slice(-4);
+      continue;
+    }
+  }
+
+  return current;
 };
 
 const getParentPath = (path: string): string => {

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -2810,6 +2810,74 @@ test('core reducer - POPULATE rule selects from array via schema and extracts va
   t.is(updatedState.data.mailingState, 'NY');
 });
 
+test('core reducer - POPULATE rule with select clears destination when no match and overwrite is true', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      table: { type: 'array' },
+      ira_custodian_location: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/table' },
+      {
+        type: 'Control',
+        scope: '#/properties/ira_custodian_location',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              from: '#/properties/table',
+              select: {
+                where: {
+                  schema: {
+                    properties: { account_type: { const: 'IRA' } },
+                    required: ['account_type'],
+                    type: 'object',
+                  },
+                },
+              },
+              valuePath: 'custodian.location',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      {
+        table: [
+          {
+            account_type: 'IRA',
+            custodian: { custodian: 'Schwab', location: 'New York' },
+          },
+        ],
+        ira_custodian_location: 'New York',
+      },
+      schema,
+      uischema
+    )
+  );
+
+  t.is(initialState.data.ira_custodian_location, 'New York');
+
+  // Change account_type from IRA to Brokerage - select finds no match
+  const updatedState = coreReducer(
+    initialState,
+    update('table.0.account_type', () => 'Brokerage')
+  );
+
+  t.is(updatedState.data.ira_custodian_location, undefined);
+});
+
 test('core reducer - POPULATE rule selects from array via schema (supports pattern/regex)', (t) => {
   const schema = {
     type: 'object',

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -2878,6 +2878,195 @@ test('core reducer - POPULATE rule with select clears destination when no match 
   t.is(updatedState.data.ira_custodian_location, undefined);
 });
 
+test('core reducer - POPULATE rule populates from hardcoded value', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: 'Default', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ flag: true, dest: '' }, schema, uischema)
+  );
+
+  t.is(initialState.data.dest, 'Default');
+
+  const clearedState = coreReducer(
+    initialState,
+    updateCore({ flag: false, dest: 'Default' }, schema, uischema)
+  );
+
+  t.is(clearedState.data.dest, undefined);
+});
+
+test('core reducer - POPULATE rule with hardcoded value uses valuePath', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: { a: 1, b: 2 },
+              valuePath: 'b',
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+
+  t.is(state.data.dest, 2);
+});
+
+test('core reducer - POPULATE rule with hardcoded value and overwrite=false does not override', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { value: 'Hardcoded', overwrite: false },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(
+    undefined,
+    init({ dest: 'Existing' }, schema, uischema)
+  );
+
+  t.is(state.data.dest, 'Existing');
+});
+
+test('core reducer - POPULATE hardcoded value reapplies on updates when condition stays true', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { value: 'test', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ dest: '' }, schema, uischema)
+  );
+  t.is(initialState.data.dest, 'test');
+
+  // Simulate user editing destination while condition remains true.
+  // Hardcoded value rules should be reapplied and restore the destination.
+  const updatedState = coreReducer(
+    initialState,
+    update('dest', () => '')
+  );
+
+  t.is(updatedState.data.dest, 'test');
+});
+
+test('core reducer - POPULATE rule with neither from nor value is skipped', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      dest: { type: 'string' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(
+    undefined,
+    init({ dest: 'Kept' }, schema, uischema)
+  );
+
+  t.is(state.data.dest, 'Kept');
+});
+
 test('core reducer - POPULATE rule selects from array via schema (supports pattern/regex)', (t) => {
   const schema = {
     type: 'object',

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -3032,6 +3032,216 @@ test('core reducer - POPULATE hardcoded value reapplies on updates when conditio
   t.is(updatedState.data.dest, 'test');
 });
 
+test('core reducer - POPULATE transforms: capitalizeFirst', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: 'hello',
+              transforms: [{ type: 'capitalizeFirst' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, 'Hello');
+});
+
+test('core reducer - POPULATE transforms: firstChar', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: 'hello',
+              transforms: [{ type: 'firstChar' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, 'h');
+});
+
+test('core reducer - POPULATE transforms: last4', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: '123456789',
+              transforms: [{ type: 'last4' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, '6789');
+});
+
+test('core reducer - POPULATE transforms: dateOnly (ISO string)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: '2026-03-30T14:05:00Z',
+              transforms: [{ type: 'dateOnly' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, '2026-03-30');
+});
+
+test('core reducer - POPULATE transforms: dateOnly (Date object)', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: new Date('2026-03-30T14:05:00Z'),
+              transforms: [{ type: 'dateOnly' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, '2026-03-30');
+});
+
+test('core reducer - POPULATE transforms: chaining', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'string' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: 'hello',
+              transforms: [{ type: 'capitalizeFirst' }, { type: 'last4' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: '' }, schema, uischema));
+  t.is(state.data.dest, 'ello');
+});
+
+test('core reducer - POPULATE transforms: non-string values are no-op', (t) => {
+  const schema = {
+    type: 'object',
+    properties: { dest: { type: 'number' } },
+  };
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: {
+              value: 123,
+              transforms: [{ type: 'capitalizeFirst' }],
+              overwrite: true,
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ dest: 0 }, schema, uischema));
+  t.is(state.data.dest, 123);
+});
+
 test('core reducer - POPULATE rule with neither from nor value is skipped', (t) => {
   const schema = {
     type: 'object',


### PR DESCRIPTION
<!--- Provide a one line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description

<!--- Describe your changes in detail -->

There are 3 changes in this PR:

1. Bug Fix (commit 1)
* Fixed POPULATE with select + overwrite: true so the destination clears when the selector finds no matching element (previously it would leave the old value).
* Added/updated reducer logic + test coverage for “no match → clear”.

2. Hardcoded Source Value Support (commit 2)
* Previously, the source could only be another form field, this extends support to a hard coded source value instead.
* Added options.populate.value as an alternative source to options.populate.from (mutually exclusive).
* Implemented a discriminated union for PopulateOptions so TypeScript enforces exactly one of from or value.
* Updated reducer behavior so value-based rules can apply reliably (including on updates) when the condition is satisfied.

3. Transformations (commit 3)
* Previously, we copied the source as-is, we now can apply transformations to the source value before populating the destination.
* Added options.populate.transforms (chainable, applied in order after select + valuePath).
* Implemented transforms:
  * capitalizeFirst
  * firstChar
  * last4
  * dateOnly (supports ISO strings and Date)
* Added reducer tests


https://github.com/user-attachments/assets/fff18b10-8573-450c-8718-d4ad64711913


https://github.com/user-attachments/assets/ef79540a-4a99-46ae-9b51-e4623b9a8b33



## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [ ] I have done a self review of my code.
- [ ] I have updated the documentation / READMEs where necessary.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
