### PR TITLE
Coerce POPULATE values to destination schema type

### DIFF
--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -60,6 +60,7 @@ import {
   isLayout,
   composePaths,
   toDataPath,
+  resolveSchema,
 } from '../util';
 import { JsonSchema } from '../models/jsonSchema';
 import {
@@ -264,6 +265,70 @@ const pathAffects = (changedPath: string, targetPath: string): boolean => {
   );
 };
 
+const resolveSchemaForScope = (
+  root: JsonSchema | undefined,
+  scope: string | undefined
+): JsonSchema | undefined => {
+  if (!root || !scope || typeof scope !== 'string' || !scope.startsWith('#')) {
+    return undefined;
+  }
+  const path = scope.slice(1);
+  return resolveSchema(root, path, root);
+};
+
+// Coerce a value to match the destination schema's declared type when the
+// types of source and destination differ in a safe, well-defined way.
+// Returns the value unchanged when:
+//   - the subschema is missing or has no type
+//   - the value already matches an allowed type
+//   - the conversion is ambiguous or lossy
+// Never throws; uncoerced mismatches surface as normal Ajv validation errors.
+const coerceToSchemaType = (
+  value: any,
+  subschema: JsonSchema | undefined
+): any => {
+  if (value === undefined || value === null) return value;
+  if (!subschema || !(subschema as any).type) return value;
+
+  const types: string[] = Array.isArray((subschema as any).type)
+    ? (subschema as any).type
+    : [(subschema as any).type];
+  const actual = typeof value;
+
+  if (
+    (actual === 'number' &&
+      (types.includes('number') ||
+        (types.includes('integer') && Number.isInteger(value)))) ||
+    (actual === 'string' && types.includes('string')) ||
+    (actual === 'boolean' && types.includes('boolean'))
+  ) {
+    return value;
+  }
+
+  if (
+    actual === 'string' &&
+    (types.includes('number') || types.includes('integer'))
+  ) {
+    const trimmed = (value as string).trim();
+    if (trimmed === '') return value;
+    const n = Number(trimmed);
+    if (!Number.isFinite(n)) return value;
+    if (types.includes('integer') && !Number.isInteger(n)) {
+      return types.includes('number') ? n : value;
+    }
+    return n;
+  }
+
+  if (actual === 'string' && types.includes('boolean')) {
+    const v = (value as string).trim().toLowerCase();
+    if (v === 'true') return true;
+    if (v === 'false') return false;
+    return value;
+  }
+
+  return value;
+};
+
 const computePopulateValue = (
   sourceValue: any,
   options: PopulateOptions,
@@ -450,7 +515,8 @@ const applyPopulateRules = (
   nextData: any,
   uischema: UISchemaElement,
   changedPath: string,
-  ajv: Ajv
+  ajv: Ajv,
+  rootSchema?: JsonSchema
 ): any => {
   if (!uischema || changedPath === undefined || changedPath === null) {
     return nextData;
@@ -459,7 +525,12 @@ const applyPopulateRules = (
   let updatedData = nextData;
   let dataChanged = false;
 
-  const applyToControl = (control: any, basePath: string) => {
+  const applyToControl = (
+    control: any,
+    basePath: string,
+    currentSchema: JsonSchema | undefined
+  ) => {
+    const destSubschema = resolveSchemaForScope(currentSchema, control.scope);
     const rules: Rule[] = Array.isArray(control.rule)
       ? control.rule
       : control.rule
@@ -625,7 +696,12 @@ const applyPopulateRules = (
         continue;
       }
 
-      if (isEqual(currentDest, newValue)) {
+      const coercedValue =
+        newValue === undefined
+          ? newValue
+          : coerceToSchemaType(newValue, destSubschema);
+
+      if (isEqual(currentDest, coercedValue)) {
         continue;
       }
 
@@ -634,18 +710,24 @@ const applyPopulateRules = (
         dataChanged = true;
       }
 
-      if (newValue === undefined) {
+      if (coercedValue === undefined) {
         updatedData = unsetFp(destPath, updatedData);
       } else {
-        updatedData = setFp(destPath, newValue, updatedData);
+        updatedData = setFp(destPath, coercedValue, updatedData);
       }
     }
   };
 
-  const traverse = (element: UISchemaElement, basePath: string) => {
+  const traverse = (
+    element: UISchemaElement,
+    basePath: string,
+    currentSchema: JsonSchema | undefined
+  ) => {
     if (isLayout(element)) {
       if (Array.isArray(element.elements)) {
-        element.elements.forEach((child) => traverse(child, basePath));
+        element.elements.forEach((child) =>
+          traverse(child, basePath, currentSchema)
+        );
       }
       return;
     }
@@ -654,7 +736,7 @@ const applyPopulateRules = (
     }
 
     const control: any = element;
-    applyToControl(control, basePath);
+    applyToControl(control, basePath, currentSchema);
 
     const detail = control.options?.detail;
     if (detail) {
@@ -668,16 +750,21 @@ const applyPopulateRules = (
         return;
       }
 
+      const arraySchema = resolveSchemaForScope(currentSchema, control.scope);
+      const rowSchema = (arraySchema as any)?.items as JsonSchema | undefined;
+
       const detailPaths = getDetailBasePaths(
         arrayPath,
         changedPath,
         updatedData
       );
-      detailPaths.forEach((detailPath) => traverse(detail, detailPath));
+      detailPaths.forEach((detailPath) =>
+        traverse(detail, detailPath, rowSchema)
+      );
     }
   };
 
-  traverse(uischema, '');
+  traverse(uischema, '', rootSchema);
 
   return updatedData;
 };
@@ -696,7 +783,8 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
         action.data,
         action.uischema,
         '',
-        thisAjv
+        thisAjv,
+        action.schema
       );
 
       // Create dynamic schema with UI-based required fields
@@ -737,7 +825,8 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
         action.data,
         action.uischema,
         '',
-        thisAjv
+        thisAjv,
+        action.schema
       );
 
       // Create dynamic schema with UI-based required fields
@@ -843,7 +932,8 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
           result,
           state.uischema,
           '',
-          state.ajv
+          state.ajv,
+          state.schema
         );
 
         // Create dynamic schema with UI-based required fields and clear hidden fields
@@ -883,7 +973,8 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
           newState,
           state.uischema,
           action.path,
-          state.ajv
+          state.ajv,
+          state.schema
         );
 
         // Create dynamic schema with UI-based required fields and clear hidden fields

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -4276,3 +4276,332 @@ test('core reducer - POPULATE updates row on source change with dot index path',
 
   t.is(updatedState.data.addresses[0].dest, 'test');
 });
+
+test('core reducer - POPULATE coerces hardcoded string value to number for number destination', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'number' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: '100', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  t.is(state.data.dest, 100);
+  t.is(typeof state.data.dest, 'number');
+});
+
+test('core reducer - POPULATE coerces hardcoded string value to integer for integer destination', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'integer' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: '42', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  t.is(state.data.dest, 42);
+  t.is(typeof state.data.dest, 'number');
+});
+
+test('core reducer - POPULATE leaves non-numeric string unchanged for number destination', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'number' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: 'abc', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  t.is(state.data.dest, 'abc');
+});
+
+test('core reducer - POPULATE leaves empty string unchanged for number destination', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'number' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: '', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  // Empty string is treated as an empty source value, so destination is cleared rather than coerced to 0.
+  t.is(state.data.dest, undefined);
+});
+
+test('core reducer - POPULATE rejects non-integer string for integer-only destination', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'integer' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: '100.5', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  t.is(state.data.dest, '100.5');
+});
+
+test('core reducer - POPULATE coerces hardcoded string to boolean', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      flag: { type: 'boolean' },
+      dest: { type: 'boolean' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/flag' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: {
+            type: 'LEAF',
+            scope: '#/properties/flag',
+            expectedValue: true,
+          },
+          options: {
+            populate: { value: 'true', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const state = coreReducer(undefined, init({ flag: true }, schema, uischema));
+
+  t.is(state.data.dest, true);
+});
+
+test('core reducer - POPULATE coerces string source field to number destination via from', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      src: { type: 'string' },
+      dest: { type: 'number' },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      { type: 'Control', scope: '#/properties/src' },
+      {
+        type: 'Control',
+        scope: '#/properties/dest',
+        rule: {
+          effect: 'POPULATE',
+          condition: { scope: '#', schema: { type: 'object' } },
+          options: {
+            populate: { from: '#/properties/src', overwrite: true },
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init({ src: '7' }, schema, uischema)
+  );
+  t.is(initialState.data.dest, 7);
+  t.is(typeof initialState.data.dest, 'number');
+
+  const updatedState = coreReducer(
+    initialState,
+    update('src', () => '99')
+  );
+  t.is(updatedState.data.dest, 99);
+  t.is(typeof updatedState.data.dest, 'number');
+});
+
+test('core reducer - POPULATE coerces hardcoded string to number inside array row detail', (t) => {
+  const schema = {
+    type: 'object',
+    properties: {
+      addresses: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            flag: { type: 'boolean' },
+            dest: { type: 'number' },
+          },
+        },
+      },
+    },
+  };
+
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/addresses',
+        options: {
+          detail: {
+            type: 'VerticalLayout',
+            elements: [
+              { type: 'Control', scope: '#/properties/flag' },
+              {
+                type: 'Control',
+                scope: '#/properties/dest',
+                rule: {
+                  effect: 'POPULATE',
+                  condition: {
+                    type: 'LEAF',
+                    scope: '#/properties/flag',
+                    expectedValue: true,
+                  },
+                  options: {
+                    populate: { value: '7', overwrite: true },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  const initialState = coreReducer(
+    undefined,
+    init(
+      { addresses: [{ flag: false }] },
+      schema,
+      uischema
+    )
+  );
+
+  const updatedState = coreReducer(
+    initialState,
+    update('addresses.0.flag', () => true)
+  );
+
+  t.is(updatedState.data.addresses[0].dest, 7);
+  t.is(typeof updatedState.data.addresses[0].dest, 'number');
+});

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -4590,11 +4590,7 @@ test('core reducer - POPULATE coerces hardcoded string to number inside array ro
 
   const initialState = coreReducer(
     undefined,
-    init(
-      { addresses: [{ flag: false }] },
-      schema,
-      uischema
-    )
+    init({ addresses: [{ flag: false }] }, schema, uischema)
   );
 
   const updatedState = coreReducer(


### PR DESCRIPTION
Number components configured with a hardcoded POPULATE value (e.g. "100") received the value as a string and surfaced "must be number" validation errors. The populate reducer now resolves the destination subschema and safely coerces string -> number/integer/boolean when the declared type calls for it; ambiguous or lossy conversions are left alone so Ajv still reports authoring mistakes.

Also covers the from/valuePath cross-type case and array row detail.

before:

https://github.com/user-attachments/assets/255d9c18-4f9d-43e3-bc0d-49b5c2b57b2a

after:

https://github.com/user-attachments/assets/24d75c8a-b022-488c-b835-fb2d77d00a8f


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If your title references a ticket, feel free to delete this section. -->

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self review of my code.
- [ ] I have updated the documentation / READMEs where necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
