### PR TITLE
[CON-2283] Fix focus being destroyed when tabbing out of date/time and text inputs

### DIFF
--- a/packages/material-renderers/src/controls/MaterialDateControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateControl.tsx
@@ -23,7 +23,13 @@
   THE SOFTWARE.
 */
 import merge from 'lodash/merge';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ControlProps,
   defaultDateFormat,
@@ -87,7 +93,23 @@ export const MaterialDateControl = (props: ControlProps) => {
     : null;
   const secondFormHelperText = showDescription && !isValid ? errors : null;
 
-  const updateChild = useCallback(() => setKey((key) => key + 1), []);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const restoreFocus = useRef(false);
+
+  const updateChild = useCallback((rerenderLosesFocus?: boolean) => {
+    restoreFocus.current = !!rerenderLosesFocus;
+    setKey((key) => key + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!restoreFocus.current) {
+      return;
+    }
+    restoreFocus.current = false;
+    // The rerender replaced the open picker button the browser was moving focus
+    // to, so focus its replacement to keep tabbing out of the field working.
+    inputRef.current?.parentElement?.querySelector('button')?.focus();
+  }, [key]);
 
   const onChange = useMemo(
     () => createOnChangeHandler(path, handleChange, saveFormat),
@@ -102,9 +124,10 @@ export const MaterialDateControl = (props: ControlProps) => {
         format,
         saveFormat,
         updateChild,
-        onBlur
+        onBlur,
+        data
       ),
-    [path, handleChange, format, saveFormat, updateChild]
+    [path, handleChange, format, saveFormat, updateChild, data]
   );
   const value = getData(data, saveFormat);
 
@@ -155,6 +178,7 @@ export const MaterialDateControl = (props: ControlProps) => {
           textField: {
             placeholder: appliedUiSchemaOptions?.placeholder,
             id: id + '-input',
+            inputRef,
             required: required && !appliedUiSchemaOptions.hideRequiredAsterisk,
             autoFocus: appliedUiSchemaOptions.focus,
             error: !isValid,

--- a/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialDateTimeControl.tsx
@@ -22,7 +22,13 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import dayjs from 'dayjs';
 import merge from 'lodash/merge';
 import {
@@ -95,7 +101,23 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
     : null;
   const secondFormHelperText = showDescription && !isValid ? errors : null;
 
-  const updateChild = useCallback(() => setKey((key) => key + 1), []);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const restoreFocus = useRef(false);
+
+  const updateChild = useCallback((rerenderLosesFocus?: boolean) => {
+    restoreFocus.current = !!rerenderLosesFocus;
+    setKey((key) => key + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!restoreFocus.current) {
+      return;
+    }
+    restoreFocus.current = false;
+    // The rerender replaced the open picker button the browser was moving focus
+    // to, so focus its replacement to keep tabbing out of the field working.
+    inputRef.current?.parentElement?.querySelector('button')?.focus();
+  }, [key]);
 
   const onChange = useMemo(
     () => createOnChangeHandler(path, handleChange, saveFormat),
@@ -110,9 +132,10 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
         format,
         saveFormat,
         updateChild,
-        onBlur
+        onBlur,
+        data
       ),
-    [path, handleChange, format, saveFormat, updateChild]
+    [path, handleChange, format, saveFormat, updateChild, data]
   );
   const value = getData(data, saveFormat);
 
@@ -163,6 +186,7 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
           textField: {
             placeholder: appliedUiSchemaOptions?.placeholder,
             id: id + '-input',
+            inputRef,
             required: required && !appliedUiSchemaOptions.hideRequiredAsterisk,
             autoFocus: appliedUiSchemaOptions.focus,
             error: !isValid,

--- a/packages/material-renderers/src/controls/MaterialInputControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialInputControl.tsx
@@ -22,7 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import {
   showAsRequired,
   ControlProps,
@@ -39,6 +39,22 @@ export interface WithInput {
 
 export const MaterialInputControl = (props: ControlProps & WithInput) => {
   const [focused, onFocus, onBlur] = useFocus();
+  const controlRef = useRef<HTMLDivElement>(null);
+
+  // Focus can move between the control's own elements, e.g. on to the clear
+  // button in the input adornment. Treating that as a blur hides the adornment
+  // while the browser is still moving focus into it, which aborts the transfer
+  // and drops focus to the document body. Let focus settle first, then check
+  // where it actually landed. relatedTarget is not usable here because React 16
+  // maps onBlur to the native blur event, which does not carry it.
+  const handleBlur = useCallback(() => {
+    setTimeout(() => {
+      const node = controlRef.current;
+      if (node && !node.contains(document.activeElement)) {
+        onBlur();
+      }
+    }, 0);
+  }, [onBlur]);
   const {
     id,
     description,
@@ -75,9 +91,10 @@ export const MaterialInputControl = (props: ControlProps & WithInput) => {
 
   return (
     <FormControl
+      ref={controlRef}
       fullWidth={!appliedUiSchemaOptions.trim}
       onFocus={onFocus}
-      onBlur={onBlur}
+      onBlur={handleBlur}
       variant={variant}
       id={id}
     >

--- a/packages/material-renderers/src/controls/MaterialTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialTimeControl.tsx
@@ -23,7 +23,13 @@
   THE SOFTWARE.
 */
 import dayjs from 'dayjs';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import merge from 'lodash/merge';
 import {
   ControlProps,
@@ -87,7 +93,23 @@ export const MaterialTimeControl = (props: ControlProps) => {
     : null;
   const secondFormHelperText = showDescription && !isValid ? errors : null;
 
-  const updateChild = useCallback(() => setKey((key) => key + 1), []);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const restoreFocus = useRef(false);
+
+  const updateChild = useCallback((rerenderLosesFocus?: boolean) => {
+    restoreFocus.current = !!rerenderLosesFocus;
+    setKey((key) => key + 1);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!restoreFocus.current) {
+      return;
+    }
+    restoreFocus.current = false;
+    // The rerender replaced the open picker button the browser was moving focus
+    // to, so focus its replacement to keep tabbing out of the field working.
+    inputRef.current?.parentElement?.querySelector('button')?.focus();
+  }, [key]);
 
   const onChange = useMemo(
     () => createOnChangeHandler(path, handleChange, saveFormat),
@@ -102,9 +124,10 @@ export const MaterialTimeControl = (props: ControlProps) => {
         format,
         saveFormat,
         updateChild,
-        onBlur
+        onBlur,
+        data
       ),
-    [path, handleChange, format, saveFormat, updateChild]
+    [path, handleChange, format, saveFormat, updateChild, data]
   );
   const value = getData(data, saveFormat);
 
@@ -137,6 +160,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
           }),
           textField: {
             id: id + '-input',
+            inputRef,
             required: required && !appliedUiSchemaOptions.hideRequiredAsterisk,
             autoFocus: appliedUiSchemaOptions.focus,
             error: !isValid,

--- a/packages/material-renderers/src/util/datejs.tsx
+++ b/packages/material-renderers/src/util/datejs.tsx
@@ -25,12 +25,20 @@ export const createOnBlurHandler =
     handleChange: (path: string, value: any) => void,
     format: string,
     saveFormat: string,
-    rerenderChild: () => void,
-    onBlur: () => void
+    rerenderChild: (restoreFocus?: boolean) => void,
+    onBlur: () => void,
+    data?: any
   ) =>
   (e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>) => {
     const date = dayjs(e.target.value, format);
     const formatedDate = formatDate(date, saveFormat);
+    // The open picker button sits next to the input and is the browser's next
+    // tab stop, so a rerender destroys the element focus is moving to. That
+    // aborts the transfer and drops focus to the document body, and the control
+    // has to put it back afterwards.
+    const losesFocusToRerender = !!(
+      e.relatedTarget && e.target.parentElement?.contains(e.relatedTarget)
+    );
     // Check if the input value is a date/time format string. Initially, a date format is sent when the user clicks the empty field.
     if (
       /^((?:[DMY]{2,4}(?:[-/:\s.]+[DMY]{2,4}){0,2}|\b[DMY]+\b)\s*)?([HhmsAa]+[-/:\s.]+[HhmsAa]+[-/:\s.]*[HhmsAa]*)?$/i.test(
@@ -38,11 +46,15 @@ export const createOnBlurHandler =
       )
     ) {
       handleChange(path, undefined);
-      rerenderChild();
-      // rerender to reset the DatePicker's internal state when field is empty.
+      // Only rerender to reset the DatePicker's internal state when there was a
+      // value to clear. Remounting an already empty field destroys the element
+      // the browser is about to focus, which breaks tabbing out of the field.
+      if (data) {
+        rerenderChild(losesFocusToRerender);
+      }
     } else if (formatedDate.toString() === 'Invalid Date') {
       handleChange(path, undefined);
-      rerenderChild();
+      rerenderChild(losesFocusToRerender);
     } else {
       handleChange(path, formatedDate);
     }

--- a/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
@@ -447,4 +447,178 @@ describe('Material date control', () => {
     // Check the placeholder attribute
     expect(inputElement.props().placeholder).toBe('Select a date');
   });
+
+  it('should not remount the picker when blurring an empty field', () => {
+    const core = initCore(schema, uischema, {});
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const inputBefore = wrapper.find('input').first().getDOMNode();
+    wrapper.find('input').first().simulate('blur');
+    wrapper.update();
+
+    // A remount replaces the input and destroys the sibling open-picker button,
+    // which is the element the browser focuses next when tabbing out.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputBefore);
+  });
+
+  it('should remount the picker when clearing a filled field', () => {
+    const core = initCore(schema, uischema, data);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const input = wrapper.find('input').first();
+    const inputBefore = input.getDOMNode();
+    (inputBefore as HTMLInputElement).value = '';
+    input.simulate('blur');
+    wrapper.update();
+
+    // The reset is still required here to clear the picker's internal state.
+    expect(wrapper.find('input').first().getDOMNode()).not.toBe(inputBefore);
+  });
+
+  it('should restore focus when clearing an invalid field remounts the picker', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+    expect(buttonBefore).toBeTruthy();
+
+    // Invalid input still has to reset the picker, which destroys the button the
+    // browser is moving focus to when tabbing out of the field.
+    inputNode.value = 'not-a-date';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should restore focus when a partially typed date remounts the picker', () => {
+    const control: ControlElement = {
+      ...uischema,
+      options: { dateFormat: 'MM/DD/YYYY' },
+    };
+    const core = initCore(schema, control, {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={control} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Only the month section was filled in. That does not parse, so the picker
+    // is reset even though the field started out empty.
+    inputNode.value = '05/DD/YYYY';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should not restore focus when an invalid field is blurred past the control', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Focus went somewhere outside the control, so the remount is not what takes
+    // it away and the control must leave it where the browser put it.
+    outside.focus();
+    inputNode.value = 'not-a-date';
+    input.simulate('blur');
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(outside);
+
+    document.body.removeChild(outside);
+  });
+
+  it('should not disturb focus when blurring a field with a valid value', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Emulate the browser having moved focus on to the open picker button.
+    buttonBefore?.focus();
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    // A valid value never resets the picker, so the tab target survives.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputNode);
+    expect(
+      (
+        wrapper.find('input').first().getDOMNode() as HTMLInputElement
+      ).parentElement?.querySelector('button')
+    ).toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonBefore);
+  });
 });

--- a/packages/material-renderers/test/renderers/MaterialDateTimeControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialDateTimeControl.test.tsx
@@ -438,6 +438,176 @@ describe('Material date time control', () => {
     input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('2005/12/10 11:22 am');
   });
+
+  it('should not remount the picker when blurring an empty field', () => {
+    const core = initCore(schema, uischema, {});
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const inputBefore = wrapper.find('input').first().getDOMNode();
+    wrapper.find('input').first().simulate('blur');
+    wrapper.update();
+
+    // A remount replaces the input and destroys the sibling open-picker button,
+    // which is the element the browser focuses next when tabbing out.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputBefore);
+  });
+
+  it('should remount the picker when clearing a filled field', () => {
+    const core = initCore(schema, uischema, data);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const input = wrapper.find('input').first();
+    const inputBefore = input.getDOMNode();
+    (inputBefore as HTMLInputElement).value = '';
+    input.simulate('blur');
+    wrapper.update();
+
+    // The reset is still required here to clear the picker's internal state.
+    expect(wrapper.find('input').first().getDOMNode()).not.toBe(inputBefore);
+  });
+
+  it('should restore focus when clearing an invalid field remounts the picker', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+    expect(buttonBefore).toBeTruthy();
+
+    // Invalid input still has to reset the picker, which destroys the button the
+    // browser is moving focus to when tabbing out of the field.
+    inputNode.value = 'not-a-date';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should restore focus when a partially typed date remounts the picker', () => {
+    const core = initCore(schema, uischema, {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Only the year section was filled in. That does not parse, so the picker
+    // is reset even though the field started out empty.
+    inputNode.value = '1980-MM-DD HH:mm';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should not restore focus when an invalid field is blurred past the control', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Focus went somewhere outside the control, so the remount is not what takes
+    // it away and the control must leave it where the browser put it.
+    outside.focus();
+    inputNode.value = 'not-a-date';
+    input.simulate('blur');
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(outside);
+
+    document.body.removeChild(outside);
+  });
+
+  it('should not disturb focus when blurring a field with a valid value', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialDateTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Emulate the browser having moved focus on to the open picker button.
+    buttonBefore?.focus();
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    // A valid value never resets the picker, so the tab target survives.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputNode);
+    expect(
+      (
+        wrapper.find('input').first().getDOMNode() as HTMLInputElement
+      ).parentElement?.querySelector('button')
+    ).toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonBefore);
+  });
 });
 
 it('should render with a placeholder', () => {

--- a/packages/material-renderers/test/renderers/MaterialTextControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialTextControl.test.tsx
@@ -30,6 +30,7 @@ import { MuiInputText } from '../../src/mui-controls/MuiInputText';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { ControlElement, ControlProps } from '@mosaic-avantos/jsonforms-core';
 import { InputAdornment, OutlinedInput } from '@mui/material';
+import { act } from 'react-dom/test-utils';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -117,5 +118,63 @@ describe('Material text control', () => {
       'display',
       'none'
     );
+  });
+
+  it('keeps the adornment shown when focus moves on to the clear button', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(createMaterialTextControl(defaultControlProps()), {
+      attachTo: container,
+    });
+
+    wrapper.find('input').first().simulate('focus');
+    wrapper.update();
+
+    const clearButton = wrapper
+      .find('button[aria-label="Clear input field"]')
+      .first()
+      .getDOMNode() as HTMLButtonElement;
+    clearButton.focus();
+
+    // Deliberately no relatedTarget, which is what React 16 reports on blur.
+    // The adornment has to stay shown regardless, or the browser cannot finish
+    // moving focus on to the button.
+    wrapper.find('input').first().simulate('blur');
+    act(() => {
+      jest.runAllTimers();
+    });
+    wrapper.update();
+
+    expect(wrapper.find(InputAdornment).props().style).not.toHaveProperty(
+      'display',
+      'none'
+    );
+    jest.useRealTimers();
+  });
+
+  it('hides the adornment once focus has left the control', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(createMaterialTextControl(defaultControlProps()), {
+      attachTo: container,
+    });
+
+    wrapper.find('input').first().simulate('focus');
+    wrapper.update();
+
+    // Focus is on the body, i.e. outside the control.
+    wrapper.find('input').first().simulate('blur');
+    act(() => {
+      jest.runAllTimers();
+    });
+    wrapper.update();
+
+    expect(wrapper.find(InputAdornment).props().style).toHaveProperty(
+      'display',
+      'none'
+    );
+    jest.useRealTimers();
   });
 });

--- a/packages/material-renderers/test/renderers/MaterialTimeControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialTimeControl.test.tsx
@@ -423,4 +423,174 @@ describe('Material time control', () => {
     input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('1//12 am');
   });
+
+  it('should not remount the picker when blurring an empty field', () => {
+    const core = initCore(schema, uischema, {});
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const inputBefore = wrapper.find('input').first().getDOMNode();
+    wrapper.find('input').first().simulate('blur');
+    wrapper.update();
+
+    // A remount replaces the input and destroys the sibling open-picker button,
+    // which is the element the browser focuses next when tabbing out.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputBefore);
+  });
+
+  it('should remount the picker when clearing a filled field', () => {
+    const core = initCore(schema, uischema, data);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>
+    );
+
+    const input = wrapper.find('input').first();
+    const inputBefore = input.getDOMNode();
+    (inputBefore as HTMLInputElement).value = '';
+    input.simulate('blur');
+    wrapper.update();
+
+    // The reset is still required here to clear the picker's internal state.
+    expect(wrapper.find('input').first().getDOMNode()).not.toBe(inputBefore);
+  });
+
+  it('should restore focus when clearing an invalid field remounts the picker', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+    expect(buttonBefore).toBeTruthy();
+
+    // Invalid input still has to reset the picker, which destroys the button the
+    // browser is moving focus to when tabbing out of the field.
+    inputNode.value = 'not-a-date';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should restore focus when a partially typed time remounts the picker', () => {
+    const core = initCore(schema, uischema, {});
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Only the hour section was filled in. That does not parse, so the picker
+    // is reset even though the field started out empty.
+    inputNode.value = '13:mm';
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonAfter);
+  });
+
+  it('should not restore focus when an invalid field is blurred past the control', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Focus went somewhere outside the control, so the remount is not what takes
+    // it away and the control must leave it where the browser put it.
+    outside.focus();
+    inputNode.value = 'not-a-time';
+    input.simulate('blur');
+    wrapper.update();
+
+    const buttonAfter = (
+      wrapper.find('input').first().getDOMNode() as HTMLInputElement
+    ).parentElement?.querySelector('button');
+    expect(buttonAfter).toBeTruthy();
+    expect(buttonAfter).not.toBe(buttonBefore);
+    expect(document.activeElement).toBe(outside);
+
+    document.body.removeChild(outside);
+  });
+
+  it('should not disturb focus when blurring a field with a valid value', () => {
+    const core = initCore(schema, uischema, data);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialTimeControl schema={schema} uischema={uischema} />
+      </JsonFormsStateProvider>,
+      { attachTo: container }
+    );
+
+    const input = wrapper.find('input').first();
+    const inputNode = input.getDOMNode() as HTMLInputElement;
+    const buttonBefore = inputNode.parentElement?.querySelector('button');
+
+    // Emulate the browser having moved focus on to the open picker button.
+    buttonBefore?.focus();
+    input.simulate('blur', { relatedTarget: buttonBefore });
+    wrapper.update();
+
+    // A valid value never resets the picker, so the tab target survives.
+    expect(wrapper.find('input').first().getDOMNode()).toBe(inputNode);
+    expect(
+      (
+        wrapper.find('input').first().getDOMNode() as HTMLInputElement
+      ).parentElement?.querySelector('button')
+    ).toBe(buttonBefore);
+    expect(document.activeElement).toBe(buttonBefore);
+  });
 });


### PR DESCRIPTION
<!--- Provide a one line summary of your changes in the Title above -->
<!--- If you're working on a ticket, please include the ticket number in the title, using the format `[ENG-XXXX] Title` -->

## Description

Problem and root cause are described in section Motivation and Context.

### Changes

- **`datejs.tsx`** — skip the remount when the stored value was already empty. `handleChange(path, undefined)` is a no-op there and MUI X's field sections are already blank, so there is nothing to reset.
- **Date / time / date-time controls** — when a remount *is* required (invalid or partially typed input, where it is load-bearing), capture that the pending focus target is inside the subtree and restore focus to the recreated button in a layout effect. Running synchronously matters: an async effect lets a drawer's focus trap claim `<body>` first.
- **`MaterialInputControl.tsx`** — don't report a blur while focus is still inside the control, so the clear button in the input adornment isn't hidden mid-transfer. Uses a deferred `document.activeElement` check rather than `relatedTarget`, which React 16 doesn't populate on `onBlur`.

No changes to public API, exports or tester ranks. `createOnBlurHandler` gained one optional trailing parameter, so existing callers are unaffected.

### Testing

All tests passing, including 20 new tests across the four controls. Each asserts the input DOM node's identity across a blur, or that focus lands on the recreated button — a remount replaces the node, so these catch the regression directly. Every new test was verified to fail without its fix.

Note jsdom cannot reproduce the failure itself (it will happily focus a `display: none` element), which is why the existing suite never caught this. The tests pin the invariants that make the browser behave. Verified manually in Chrome.

## Motivation and Context

### Problem

Tabbing out of a date, time or date-time field destroyed focus. On a plain form focus fell to `<body>` and the next Tab returned to the same field, trapping the user in a loop; inside a drawer the focus trap redirected to the drawer's close button. Affected every form with a date/time field. Text inputs with a value showed the same symptom.

### Cause

On blur, these controls bump a `key` on the picker, remounting the whole subtree. The browser's next tab stop is MUI X's open-picker button, which lives *inside* that subtree — so the input's own blur handler destroyed the element focus was moving to, aborting the transfer.

The empty-field case was a regression from ACT-458, which removed a guard added by ENG3-571 (`// don't rerender so user can click the date picker.`). The invalid-input case is inherited from upstream and still present there.

## Checklist:

<!--- Go over all the following points, and check them off before requesting a review. -->
<!--- You can either check them off by adding an `x` in the square brackets, or you can click the checkbox in the GitHub UI after you create the PR. -->
<!--- If you're unsure about any of these, feel free to ask in #engineering. -->

- [x] I have done a self review of my code.
- [x] I have updated the documentation / READMEs where necessary.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have looked for existing abstractions (helper functions, React components) that AI-generated code may not be using
